### PR TITLE
added prefixes for tì-us nouns and changed lenition logic for prefixes

### DIFF
--- a/affixes.go
+++ b/affixes.go
@@ -444,8 +444,8 @@ func (w *Word) suffix(target string, previousAttempt string) string {
 		reString = strings.Replace(previousAttempt, "a", "[ae]", -1) + reString
 	} else if w.Navi == "tsaw" {
 		tsaSuf := []string{
-			"mungwrr", "kxamlä", "tafkip", "pxisre", "pximaw", "ftumfa", "mìkam", "nemfa", "takip", "lisre", "talun",
-			"krrka", "teri", "fkip", "pxaw", "pxel", "luke", "rofa", "fpi", "ftu", "kip", "vay", "lok", "maw", "sìn", "sre",
+			"mungwrr", "kxamlä", "tafkip", "pxisre", "pximaw", "ftumfa", "mìkam", "nemfa", "takip", "lisre", "talun", "ftuopa",
+			"krrka", "teri", "fkip", "pxaw", "pxel", "luke", "rofa", "fpi", "ftu", "kip", "vay", "lok", "maw", "sìn", "sre", "ìlä", "raw",
 			"few", "kam", "kay", "nuä", "sko", "yoa", "äo", "eo", "fa", "hu", "ka", "mì", "na", "ne", "ta", "io", "uo",
 			"ro", "wä", "ìri", "ri", "ru", "ti", "r"}
 		for _, s := range tsaSuf {

--- a/affixes.go
+++ b/affixes.go
@@ -347,7 +347,7 @@ func (w *Word) suffix(target string, previousAttempt string) string {
 	const (
 		adjSufRe string = "(a|sì)?$"
 		// -to as suffix to nouns and made -sì|-to as separate option
-		nSufRe string = "(nga'|tsyìp|tu|fkeyk)?(o)?(pe)?(mungwrr|kxamlä|tafkip|pxisre|pximaw|ftumfa|mìkam|nemfa|takip|lisre|talun|krrka|teri|fkip|pxaw|pxel|luke|rofa|fpi|ftu|kip|vay|lok|maw|sìn|sre|few|kam|kay|nuä|sko|yoa|äo|eo|fa|hu|ka|mì|na|ne|ta|io|uo|ro|wä|ìri|ìl|eyä|yä|ä|it|ri|ru|ti|ur|l|r|t)?(to|sì)?$"
+		nSufRe string = "(nga'|tsyìp|tu|fkeyk)?(o)?(pe)?(mungwrr|kxamlä|tafkip|pxisre|pximaw|ftumfa|ftuopa|mìkam|nemfa|takip|lisre|talun|krrka|teri|fkip|pxaw|pxel|luke|rofa|fpi|ftu|kip|vay|lok|maw|sìn|sre|few|raw|kam|kay|nuä|sko|yoa|äo|eo|fa|hu|ka|mì|na|ne|ta|io|uo|ro|wä|ìlä|ìri|ìl|eyä|yä|ä|it|ri|ru|ti|ur|l|r|t)?(to|sì)?$"
 		ngey   string = "ngey"
 	)
 

--- a/fwew.go
+++ b/fwew.go
@@ -51,6 +51,9 @@ func (w *Word) similarity(other string) float64 {
 	if w.Navi == "nga" && other == "ngey" {
 		return 1.0
 	}
+	if w.Navi == "'ia" && strings.HasSuffix(other, "ì'usiä") {
+		return 1.0
+	}
 	vowels := "aäeiìoulr"
 	w0v := intersection(w.Navi, vowels)
 	w1v := intersection(other, vowels)


### PR DESCRIPTION
1. Separated tì-us/sì-us nouns recognition from participles
2. Added prefixes to tì-us/sì-us (including leniting)
3. Changed checking prefixes for being lenitable, so it would find lenited and not lenited forms only when they are valid.
4. Reworked output and logic for -usia nouns, so they would work fine with current changes.
5. Added back a- prefix to output for adjectives and participles
6. Added -to as noun suffix and together with -sì separated them from others, so declensed nouns could have sì/to.