### PR TITLE
Improvement Si

### DIFF
--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -1,6 +1,7 @@
 package fwew_lib
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -168,6 +169,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 		return candidates
 	}
 	if !isDuplicate(input) {
+		fmt.Println(input.word)
 		candidates = append(candidates, input)
 		newString := ""
 
@@ -185,6 +187,8 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 				newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "a")
 				newCandidate.insistPOS = "adj."
 				deconjugateHelper(newCandidate, 1, suffixCheck, -1, false)
+				newCandidate.insistPOS = "v."
+				deconjugateHelper(newCandidate, 1, suffixCheck, -1, true)
 			} else if strings.HasPrefix(input.word, "nì") {
 				newCandidate := candidateDupe(input)
 				newCandidate.word = strings.TrimPrefix(input.word, "nì")
@@ -378,6 +382,8 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 				newCandidate.word = newString
 				newCandidate.insistPOS = "adj."
 				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "a")
+				deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, true)
+				newCandidate.insistPOS = "v."
 				deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, true)
 			}
 			for _, oldSuffix := range lastSuffixes {

--- a/fwew.go
+++ b/fwew.go
@@ -203,8 +203,7 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 						break
 					} else {
 						// For "[word] ke si and [word] rä'ä si"
-						// "ke" only goes before the verb it negates, while "rä'ä" can come before or after
-						if (allWords[i+j+1] == "ke" && IsVerb(allWords[i+j+2])) || (allWords[i+j+1] == "rä'ä" && IsVerb(allWords[i+j]+" "+allWords[i+j+2])) {
+						if (allWords[i+j+1] == "ke" || allWords[i+j+1] == "rä'ä") && IsVerb(allWords[i+j+2]) {
 							extraWord = 1
 							results = [][]Word{}
 							results = append(results, []Word{})
@@ -297,8 +296,7 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 						if i+j+1 >= len(allWords) {
 							break
 						} else {
-							// "ke" only goes before the verb it negates, while "rä'ä" can come before or after
-							if (allWords[i+j+1] == "ke" && IsVerb(allWords[i+j+2])) || (allWords[i+j+1] == "rä'ä" && IsVerb(allWords[i+j]+" "+allWords[i+j+2])) {
+							if (allWords[i+j+1] == "ke" || allWords[i+j+1] == "rä'ä") && IsVerb(allWords[i+j+2]) {
 								extraWord = 1
 								results = [][]Word{}
 								results = append(results, []Word{})


### PR DESCRIPTION
Can now detect better:
- S<us>i and S<ats>i
- [word]-susi, a[word]-susi and [word]-susia
- [word] ke si and [word] rä'ä si, as well as win ke säpi and win rä'ä säpi
- Case endings on [word]siyu
- Tsa-[adposition] is now recognized, shown as tsaw with adposition endings (as per [this](https://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/#comment-912))