### PR TITLE
Recognizes zekwä-äo and fya'o-o

### DIFF
--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -449,7 +449,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 							newCandidate.word = strings.TrimSuffix(newString, "e") + "o"
 							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
 						} else if vowel, ok := vowelSuffixes[oldSuffix]; ok {
-							// Make sure zekwä-äo and fya'o-o are recognized
+							// Make sure zekwä-äo is recognized
 							if strings.HasSuffix(newString, vowel+"-") {
 								newString = strings.TrimSuffix(newString, "-")
 								newCandidate.word = newString
@@ -501,7 +501,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 
 					// Make sure fya'o-o is recognized
 					if vowel, ok := vowelSuffixes[oldSuffix]; ok {
-						// Make sure zekwä-äo and fya'o-o are recognized
+						// Make sure fya'o-o is recognized
 						if strings.HasSuffix(newString, vowel+"-") {
 							newString = strings.TrimSuffix(newString, "-")
 							newCandidate.word = newString

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -103,6 +103,7 @@ var adposuffixes = []string{
 	"vay", "kay",
 }
 var determinerSuffixes = []string{"pe", "o"}
+var vowelSuffixes = map[string]string{"äo": "ä", "eo": "e", "io": "i", "uo": "u", "ìlä": "ì", "o": "o"}
 var stemSuffixes = []string{"tsyìp", "fkeyk"}
 var verbSuffixes = []string{"tswo", "yu"}
 
@@ -447,6 +448,13 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 							// sneyä -> sno
 							newCandidate.word = strings.TrimSuffix(newString, "e") + "o"
 							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+						} else if vowel, ok := vowelSuffixes[oldSuffix]; ok {
+							// Make sure zekwä-äo and fya'o-o are recognized
+							if strings.HasSuffix(newString, vowel+"-") {
+								newString = strings.TrimSuffix(newString, "-")
+								newCandidate.word = newString
+								deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+							}
 						}
 					}
 				}
@@ -490,6 +498,16 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 					newCandidate.insistPOS = "n."
 					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
 					deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+
+					// Make sure fya'o-o is recognized
+					if vowel, ok := vowelSuffixes[oldSuffix]; ok {
+						// Make sure zekwä-äo and fya'o-o are recognized
+						if strings.HasSuffix(newString, vowel+"-") {
+							newString = strings.TrimSuffix(newString, "-")
+							newCandidate.word = newString
+							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+						}
+					}
 				}
 			}
 			fallthrough


### PR DESCRIPTION
Just for adpositions and "o" at the end of words that otherwise have them.  It still recognizes forms without hyphens though.