### PR TITLE
Various fixes

### DIFF
--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -130,7 +130,6 @@ func isDuplicate(input ConjugationCandidate) bool {
 					return true
 				}
 			}
-
 		}
 	}
 	return false

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -174,12 +174,16 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			// Canonized in:
 			// https://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/#comment-912
 			input.word = "tsaw"
-			candidates = append(candidates, input)
+			if !isDuplicate(input) {
+				candidates = append(candidates, input)
+			}
 			return candidates
 		} else if input.word == "oenga" {
 			// The a re-appears when case endings are added (it uses a instead of ì)
 			input.word = "oeng"
-			candidates = append(candidates, input)
+			if !isDuplicate(input) {
+				candidates = append(candidates, input)
+			}
 			return candidates
 		}
 	}
@@ -236,7 +240,9 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			if aPosition == 1 {
 				newCandidate.suffixes = append(newCandidate.suffixes, "a")
 			}
-			candidates = append(candidates, newCandidate)
+			if !isDuplicate(input) {
+				candidates = append(candidates, newCandidate)
+			}
 		}
 		return candidates
 	}
@@ -612,7 +618,6 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 				}
 			}
 		}
-
 		return candidates
 	}
 	return nil

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -125,7 +125,12 @@ var second = []string{"ei", "eiy", "äng", "eng", "uy", "ats"}
 func isDuplicate(input ConjugationCandidate) bool {
 	for _, a := range candidates {
 		if input.word == a.word && input.insistPOS == a.insistPOS {
-			return true
+			if len(input.prefixes) == len(a.prefixes) && len(input.suffixes) == len(a.suffixes) {
+				if len(input.infixes) == len(a.infixes) {
+					return true
+				}
+			}
+
 		}
 	}
 	return false

--- a/fwew.go
+++ b/fwew.go
@@ -800,6 +800,11 @@ func GetHomonyms() (results [][]Word, err error) {
 	return TranslateFromNaviHash(homonyms, false)
 }
 
+// Get all words with multiple definitions
+func GetMultiIPA() (results [][]Word, err error) {
+	return TranslateFromNaviHash(multiIPA, false)
+}
+
 func EjectiveSoftener(ipa string, oldLetter string, newLetter string) (newIpa string) {
 	ipa = "." + ipa
 


### PR DESCRIPTION
Inspired by the issues page on [Reykunyu](https://github.com/Willem3141/navi-reykunyu/issues).

- Made secondary pronunciations searchable if they show up in the IPA, such as _nawnomum_, _nayweng_ and _ronsrewngop_
- _Luyu_ now shows up as both _lu-yu_ and _l<uy>u_
- `/multi-ipa` shows all words with more than one IPA
- Fixed a bug where _sey_ would show two results for _tsaw_ in addition to _sey_

Still no way to catch special cases for [case endings on loanwords](https://naviteri.org/2022/01/aawa-tipangkxotsyip-a-teri-horen-lifyaya-a-few-little-discussions-about-grammar/) though.