### PR TITLE
Command to see if something is phonotactically valid in Na'vi

### DIFF
--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -91,9 +91,9 @@ var adposuffixes = []string{
 	// Sorted alphabetically by their reverse forms
 	"nemfa", "rofa", "ka", "fa", "na", "ta", "ya", //-a
 	"lisre", "pxisre", "sre", "luke", "ne", //-e
-	"fpi", //-i
-	"mì", //-ì
-	"lok", //-k
+	"fpi",          //-i
+	"mì",           //-ì
+	"lok",          //-k
 	"mìkam", "kam", //-m
 	"ken", "sìn", //-n
 	"äo", "eo", "io", "uo", "ro", "to", //-o
@@ -699,7 +699,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 									a.Affixes.Prefix = candidate.prefixes
 									a.Affixes.Infix = candidate.infixes
 									a.Affixes.Suffix = candidate.suffixes
-									results = append(results, a)
+									results = AppendAndAlphabetize(results, a)
 									break
 								}
 							}
@@ -711,7 +711,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 							a.Affixes.Prefix = candidate.prefixes
 							a.Affixes.Infix = candidate.infixes
 							a.Affixes.Suffix = candidate.suffixes
-							results = append(results, a)
+							results = AppendAndAlphabetize(results, a)
 						}
 					}
 				}
@@ -729,9 +729,9 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						a.Affixes.Prefix = candidate.prefixes
 						a.Affixes.Infix = candidate.infixes
 						a.Affixes.Suffix = candidate.suffixes
-						results = append(results, a)
+						results = AppendAndAlphabetize(results, a)
 					} else {
-						results = append(results, infixError(searchNaviWord, "Did you mean **tì"+rebuiltVerb+"**?", c.IPA))
+						results = AppendAndAlphabetize(results, infixError(searchNaviWord, "Did you mean **tì"+rebuiltVerb+"**?", c.IPA))
 					}
 				}
 			} else if candidate.insistPOS == "n." {
@@ -742,7 +742,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						a.Affixes.Lenition = candidate.lenition
 						a.Affixes.Prefix = candidate.prefixes
 						a.Affixes.Suffix = candidate.suffixes
-						results = append(results, a)
+						results = AppendAndAlphabetize(results, a)
 					}
 				}
 			} else if candidate.insistPOS == "pn." {
@@ -752,7 +752,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 					a.Affixes.Lenition = candidate.lenition
 					a.Affixes.Prefix = candidate.prefixes
 					a.Affixes.Suffix = candidate.suffixes
-					results = append(results, a)
+					results = AppendAndAlphabetize(results, a)
 				}
 			} else if candidate.insistPOS == "adj." {
 				posNoun := c.PartOfSpeech
@@ -761,7 +761,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 					a.Affixes.Lenition = candidate.lenition
 					a.Affixes.Prefix = candidate.prefixes
 					a.Affixes.Suffix = candidate.suffixes
-					results = append(results, a)
+					results = AppendAndAlphabetize(results, a)
 				}
 			} else if candidate.insistPOS == "v." {
 				posNoun := c.PartOfSpeech
@@ -827,7 +827,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						if len(candidate.infixes) > 0 {
 							continue // No nonsense here
 						} else {
-							results = append(results, a)
+							results = AppendAndAlphabetize(results, a)
 						}
 					}
 
@@ -899,21 +899,21 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 					}
 
 					if identicalRunes(rebuiltVerb, strings.ReplaceAll(searchNaviWord, "-", " ")) {
-						results = append(results, a)
+						results = AppendAndAlphabetize(results, a)
 					} else if participle {
 						// In case we have a [word]-susi
 						rebuiltHyphen := strings.ReplaceAll(searchNaviWord, "-", " ")
 						if identicalRunes("a"+rebuiltVerb, rebuiltHyphen) {
 							// a-v<us>erb and a-v<awn>erb
-							results = append(results, a)
+							results = AppendAndAlphabetize(results, a)
 						} else if identicalRunes(rebuiltVerb+"a", rebuiltHyphen) {
 							// v<us>erb-a and v<awn>erb-a
-							results = append(results, a)
+							results = AppendAndAlphabetize(results, a)
 						} else if firstInfixes == "us" {
-							results = append(results, infixError(searchNaviWord, "Did you mean **"+rebuiltVerb+"**?", c.IPA))
+							results = AppendAndAlphabetize(results, infixError(searchNaviWord, "Did you mean **"+rebuiltVerb+"**?", c.IPA))
 						}
 					} else if gerund { // ti is needed to weed out non-productive tì-verbs
-						results = append(results, infixError(searchNaviWord, "Did you mean **"+rebuiltVerb+"**?", c.IPA))
+						results = AppendAndAlphabetize(results, infixError(searchNaviWord, "Did you mean **"+rebuiltVerb+"**?", c.IPA))
 					}
 				}
 			} else if candidate.insistPOS == "nì." {
@@ -923,14 +923,14 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 					a.Affixes.Lenition = candidate.lenition
 					a.Affixes.Prefix = candidate.prefixes
 					a.Affixes.Suffix = candidate.suffixes
-					results = append(results, a)
+					results = AppendAndAlphabetize(results, a)
 				}
 			} else if len(candidate.infixes) == 0 {
 				a := c
 				a.Affixes.Lenition = candidate.lenition
 				a.Affixes.Prefix = candidate.prefixes
 				a.Affixes.Suffix = candidate.suffixes
-				results = append(results, a)
+				results = AppendAndAlphabetize(results, a)
 			}
 		}
 	}

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -88,21 +88,19 @@ var adposuffixes = []string{
 	"teri", //"topical"
 	// Case endings
 	"ìl", "l", "it", "ti", "t", "ur", "ru", "r", "yä", "ä", "ìri", "ri",
-	// Alphabetized the reverse of these things with exceptions for mistaken ones
-	"nemfa", "rofa", "ka", "fa", "na", "ta",
-	"lisre", "pxisre", "sre", "luke", "ne",
-	"fpi",
-	"mì",
-	"lok",
-	"mìkam", "kam",
-	"sìn",
-	"äo", "eo", "io", "uo", "ro",
-	"tafkip", "takip", "fkip", "kip",
-	"ftu", "hu",
-	"pximaw", "maw", "pxaw", "few",
-	"vay", "kay",
-	"ken",
-	"to",
+	// Sorted alphabetically by their reverse forms
+	"nemfa", "rofa", "ka", "fa", "na", "ta", "ya", //-a
+	"lisre", "pxisre", "sre", "luke", "ne", //-e
+	"fpi", //-i
+	"mì", //-ì
+	"lok", //-k
+	"mìkam", "kam", //-m
+	"ken", "sìn", //-n
+	"äo", "eo", "io", "uo", "ro", "to", //-o
+	"tafkip", "takip", "fkip", "kip", //-p
+	"ftu", "hu", //-u
+	"pximaw", "maw", "pxaw", "few", //-w
+	"vay", "kay", //-y
 }
 
 var vowelSuffixes = map[string]string{"äo": "ä", "eo": "e", "io": "i", "uo": "u", "ìlä": "ì", "o": "o"}

--- a/cache.go
+++ b/cache.go
@@ -17,6 +17,7 @@ var dictHashCached bool
 var dictHash2 MetaDict
 var dictHash2Cached bool
 var homonyms string
+var oddballs string
 var multiIPA string
 
 type MetaDict struct {
@@ -448,6 +449,11 @@ func CacheDictHash() error {
 			if secondTerm != standardizedWord {
 				dictHash[secondTerm] = append(dictHash[secondTerm], word)
 			}
+		}
+
+		// See whether or not it violates normal phonotactic rules like Jakesully or Oìsss
+		if !strings.Contains(IsValidNavi(standardizedWord), "Valid:") {
+			oddballs += standardizedWord + " "
 		}
 
 		return nil

--- a/cache.go
+++ b/cache.go
@@ -452,7 +452,15 @@ func CacheDictHash() error {
 		}
 
 		// See whether or not it violates normal phonotactic rules like Jakesully or Oìsss
-		if !strings.Contains(IsValidNavi(standardizedWord), "Valid:") {
+		valid := true
+		for _, a := range strings.Split(IsValidNavi(standardizedWord), "\n") {
+			// Check every word.  If one of them isn't good, write down the word
+			if len(a) > 0 && !strings.Contains(a, "Valid:") {
+				valid = false
+				break
+			}
+		}
+		if !valid {
 			oddballs += standardizedWord + " "
 		}
 

--- a/fwew.go
+++ b/fwew.go
@@ -796,6 +796,12 @@ func GetHomonyms() (results [][]Word, err error) {
 	return TranslateFromNaviHash(homonyms, false)
 }
 
+// Get all words with non-standard phonotactics
+func GetOddballs() (results [][]Word, err error) {
+	fmt.Println(oddballs)
+	return TranslateFromNaviHash(oddballs, false)
+}
+
 // Get all words with multiple definitions
 func GetMultiIPA() (results [][]Word, err error) {
 	return TranslateFromNaviHash(multiIPA, false)

--- a/fwew.go
+++ b/fwew.go
@@ -798,8 +798,7 @@ func GetHomonyms() (results [][]Word, err error) {
 
 // Get all words with non-standard phonotactics
 func GetOddballs() (results [][]Word, err error) {
-	fmt.Println(oddballs)
-	return TranslateFromNaviHash(oddballs, false)
+	return TranslateFromNaviHash(oddballs, true)
 }
 
 // Get all words with multiple definitions

--- a/fwew.go
+++ b/fwew.go
@@ -329,15 +329,11 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 		if len(results) > 0 && len(results[0]) > 0 {
 			if !(strings.ToLower(results[len(results)-1][0].Navi) != searchNaviWord && strings.HasPrefix(strings.ToLower(results[len(results)-1][0].Navi), searchNaviWord)) {
 				// Find all possible unconjugated versions of the word
-				for _, a := range TestDeconjugations(searchNaviWord) {
-					results[len(results)-1] = AppendAndAlphabetize(results[len(results)-1], a)
-				}
+				results[len(results)-1] = append(results[len(results)-1], TestDeconjugations(searchNaviWord)...)
 			}
 		} else {
 			// Find all possible unconjugated versions of the word
-			for _, a := range TestDeconjugations(searchNaviWord) {
-				results[len(results)-1] = AppendAndAlphabetize(results[len(results)-1], a)
-			}
+			results[len(results)-1] = append(results[len(results)-1], TestDeconjugations(searchNaviWord)...)
 		}
 
 		// Check if the word could have more than one word
@@ -1050,6 +1046,16 @@ func ReefMe(ipa string, inter bool) []string {
 }
 
 func StartEverything() {
+	fmt.Println(IsValidNavi("atxkxrrnga"))
+	fmt.Println(IsValidNavi("tobeygwey"))
+	fmt.Println(IsValidNavi("prrkxentrrkrr"))
+	fmt.Println(IsValidNavi("prrt"))
+	fmt.Println(IsValidNavi("lat"))
+	fmt.Println(IsValidNavi("ngtskxey"))
+	fmt.Println(IsValidNavi("nìkt'syey"))
+	fmt.Println(IsValidNavi("yoy"))
+	fmt.Println(IsValidNavi("'ah"))
+	fmt.Println(IsValidNavi("ngtskx"))
 	AssureDict()
 	CacheDictHash()
 	CacheDictHash2()

--- a/fwew.go
+++ b/fwew.go
@@ -1046,16 +1046,6 @@ func ReefMe(ipa string, inter bool) []string {
 }
 
 func StartEverything() {
-	fmt.Println(IsValidNavi("atxkxrrnga"))
-	fmt.Println(IsValidNavi("tobeygwey"))
-	fmt.Println(IsValidNavi("prrkxentrrkrr"))
-	fmt.Println(IsValidNavi("prrt"))
-	fmt.Println(IsValidNavi("lat"))
-	fmt.Println(IsValidNavi("ngtskxey"))
-	fmt.Println(IsValidNavi("nìkt'syey"))
-	fmt.Println(IsValidNavi("yoy"))
-	fmt.Println(IsValidNavi("'ah"))
-	fmt.Println(IsValidNavi("ngtskx"))
 	AssureDict()
 	CacheDictHash()
 	CacheDictHash2()

--- a/lib.go
+++ b/lib.go
@@ -268,7 +268,7 @@ func SHA1Hash(filename string) string {
 // compress compresses or normalizes each digraph of the given string to a unique single character
 // inverse of `func decompress(compressed string) string`
 func compress(syllables string) string {
-	syll := strings.ToLower(syllables)
+	syll := syllables
 
 	ct := make(map[string]string)
 	ct["kx"] = "q"
@@ -290,7 +290,7 @@ func compress(syllables string) string {
 }
 
 func decompress(syllables string) string {
-	syll := strings.ToLower(syllables)
+	syll := syllables
 
 	ct := make(map[string]string)
 	ct["q"] = "kx"

--- a/lib.go
+++ b/lib.go
@@ -288,3 +288,25 @@ func compress(syllables string) string {
 
 	return strings.Replace(syll, "-", "", -1)
 }
+
+func decompress(syllables string) string {
+	syll := strings.ToLower(syllables)
+
+	ct := make(map[string]string)
+	ct["q"] = "kx"
+	ct["b"] = "px"
+	ct["d"] = "tx"
+	ct["g"] = "ng"
+	ct["c"] = "ts"
+	ct["0"] = "rr"
+	ct["1"] = "ll"
+	ct["2"] = "aw"
+	ct["3"] = "ay"
+	ct["4"] = "ew"
+	ct["5"] = "ey"
+	for key := range ct {
+		syll = strings.Replace(syll, key, ct[key], -1)
+	}
+
+	return syll
+}

--- a/list.go
+++ b/list.go
@@ -102,11 +102,11 @@ func filterWord(results []Word, word Word, args []string, checkDigraphs uint8) [
 
 	switch checkDigraphs {
 	case 1: // 1: compress spec and syllables (consider all digraphs)
-		spec = compress(spec)
+		spec = compress(strings.ToLower(spec))
 		fallthrough
 	case 2: // 2: compress syllables, but not spec (find fake digraphs)
-		syllables = compress(syllables)
-		navi = compress(navi)
+		syllables = compress(strings.ToLower(syllables))
+		navi = compress(strings.ToLower(navi))
 	}
 
 	syllables = strings.ReplaceAll(syllables, "-", "")
@@ -194,7 +194,7 @@ func filterNumeric(results []Word, word Word, args []string) (filtered []Word, e
 	whatMap := map[string]int{
 		Text("w_syllables"): word.SyllableCount(),
 		Text("w_stress"):    istress,
-		Text("w_length"):    utf8.RuneCountInString(compress(word.Syllables)),
+		Text("w_length"):    utf8.RuneCountInString(compress(strings.ToLower(word.Syllables))),
 	}
 
 	condMap := map[string]bool{

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -5,6 +5,17 @@ import (
 	"strings"
 )
 
+var cluster_1 = []string{"f", "s", "c"}
+var cluster_2 = []string{"k", "q", "l", "m", "n", "g", "p",
+	"b", "t", "d", "r", "w", "y"}
+var letters_start = []string{"", "p", "t", "k", "b", "d", "q", "'",
+	"m", "n", "g", "r", "l", "w", "y",
+	"f", "v", "s", "z", "c", "h", "B", "D", "G"}
+var letters_end = []string{"", "p", "t", "k", "b", "d", "q", "'",
+	"m", "n", "l", "r", "g"}
+
+var letters_map = map[string]string{}
+
 // See if a word is phonotactically valid in Na'vi
 func IsValidNaviHelper(word string) string {
 	oldWord := word
@@ -117,33 +128,6 @@ func IsValidNaviHelper(word string) string {
 	}
 
 	// Phase 2.1: Go through syllable boundaries
-	cluster_1 := []string{"f", "s", "c"}
-	cluster_2 := []string{"k", "q", "l", "m", "n", "g", "p",
-		"b", "t", "d", "r", "w", "y"}
-	letters_start := []string{"", "p", "t", "k", "b", "d", "q", "'",
-		"m", "n", "g", "r", "l", "w", "y",
-		"f", "v", "s", "z", "c", "h", "B", "D", "G"}
-	letters_end := []string{"", "p", "t", "k", "b", "d", "q", "'",
-		"m", "n", "l", "r", "g"}
-
-	letters_map := map[string]string{}
-	for _, a := range letters_end {
-		for _, b := range letters_start {
-			// Do not assume a thing comes at the end of a word if it doesn't have to
-			if !(a != "" && b == "") {
-				letters_map[a+b] = a + "-" + b
-			}
-		}
-		for _, b := range cluster_1 {
-			for _, c := range cluster_2 {
-				// Do not assume a thing comes at the end of a word if it doesn't have to
-				if !(a != "" && b == "") {
-					letters_map[a+b+c] = a + "-" + b + c
-				}
-			}
-		}
-	}
-
 	syllable_breakdown := ""
 
 	for i, a := range strings.Split(syllable_boundaries, ".") {
@@ -272,6 +256,25 @@ func IsValidNaviHelper(word string) string {
 }
 
 func IsValidNavi(word string) string {
+	// Let it know of valid syllable boundaries
+	if len(letters_map) == 0 {
+		for _, a := range letters_end {
+			for _, b := range letters_start {
+				// Do not assume a thing comes at the end of a word if it doesn't have to
+				if !(a != "" && b == "") {
+					letters_map[a+b] = a + "-" + b
+				}
+			}
+			for _, b := range cluster_1 {
+				for _, c := range cluster_2 {
+					// Do not assume a thing comes at the end of a word if it doesn't have to
+					if !(a != "" && b == "") {
+						letters_map[a+b+c] = a + "-" + b + c
+					}
+				}
+			}
+		}
+	}
 	results := ""
 	for i, a := range strings.Split(word, " ") {
 		newLine := IsValidNaviHelper(a) + "\n"

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -239,7 +239,7 @@ syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "ng", "0")
 		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "sy", "sh")
 		isReef = " (in reef dialect)"
 	}
-	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "ng", "0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "0", "ng")
 
 	return oldWord + " Valid: " + syllable_breakdown + isReef
 }

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -1,6 +1,7 @@
 package fwew_lib
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -43,7 +44,7 @@ func IsValidNaviHelper(word string) string {
 	}
 
 	if len(nonNaviLetters) > 0 {
-		return oldWord + " Has letters not in Na'vi: " + nonNaviLetters
+		return "**" + oldWord + "** Has letters not in Na'vi: " + nonNaviLetters
 	}
 
 	// Phase 1: don't confuse the digraph compression things
@@ -83,7 +84,7 @@ func IsValidNaviHelper(word string) string {
 	tempWord = strings.ReplaceAll(tempWord, "nG", "ng")
 
 	if badLetters != "" {
-		return oldWord + " Invalid letters: " + badLetters
+		return "**" + oldWord + "** Invalid letters: `" + badLetters + "`"
 	}
 
 	// Phase 2: Compress digraphs and divide into syllable boundaries
@@ -112,7 +113,7 @@ func IsValidNaviHelper(word string) string {
 	}
 
 	if len(word_nuclei) == 0 {
-		return "Error: could not find any syllable nuclei in " + oldWord
+		return "**" + oldWord + "** Error: could not find any syllable nuclei"
 	}
 
 	// Phase 2.1: Go through syllable boundaries
@@ -150,7 +151,7 @@ func IsValidNaviHelper(word string) string {
 		if b, ok := letters_map[a]; ok {
 			syllable_breakdown = syllable_breakdown + b
 		} else {
-			return oldWord + " Invalid consonants: \"" + strings.ToLower(decompress(a)) + "\""
+			return "**" + oldWord + "** Invalid consonant combination: `" + strings.ToLower(decompress(a)) + "`"
 		}
 		if i < len(word_nuclei) {
 			syllable_breakdown = syllable_breakdown + string(word_nuclei[i])
@@ -174,7 +175,7 @@ func IsValidNaviHelper(word string) string {
 	}
 
 	if !contains[0] {
-		return oldWord + " Incomplete syllables: \"" + strings.ToLower(decompress(syllable_breakdown)) + "\""
+		return "**" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
 	}
 
 	if !contains[1] {
@@ -187,7 +188,7 @@ func IsValidNaviHelper(word string) string {
 		}
 
 		if !can_end_a_word {
-			return oldWord + " Incomplete syllables: \"" + strings.ToLower(decompress(syllable_breakdown)) + "\""
+			return "**" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
 		}
 
 		can_coda := false
@@ -200,7 +201,7 @@ func IsValidNaviHelper(word string) string {
 		}
 
 		if !can_coda {
-			return oldWord + " Incomplete syllables: \"" + strings.ToLower(decompress(syllable_breakdown)) + "\""
+			return "**" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
 		}
 
 		syllable_breakdown_temp := ""
@@ -218,14 +219,18 @@ func IsValidNaviHelper(word string) string {
 	// Finally, psuedovowels cannot accept codas
 	for _, a := range letters_end {
 		if a != "" && (strings.Contains(syllable_breakdown, "0"+a) || strings.Contains(syllable_breakdown, "1"+a)) {
-			return oldWord + " Psuedovowels can't accept codas: " + decompress(strings.ToLower(syllable_breakdown))
+			return "**" + oldWord + "** Psuedovowels can't accept codas: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
 		}
 	}
 
 	if strings.Contains(syllable_breakdown, "-0-") || strings.Contains(syllable_breakdown, "-1-") ||
 		strings.HasPrefix(syllable_breakdown, "0") || strings.HasPrefix(syllable_breakdown, "1") ||
 		strings.HasSuffix(syllable_breakdown, "-0") || strings.HasSuffix(syllable_breakdown, "-1") {
-		return oldWord + " Psuedovowels must have onsets: " + decompress(strings.ToLower(syllable_breakdown))
+		return "**" + oldWord + "** Psuedovowels must have onsets: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
+	}
+
+	if strings.Contains(syllable_breakdown, "0-r") || strings.Contains(syllable_breakdown, "1-l") {
+		return "**" + oldWord + "** Triple Rs or Ls aren't allowed: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
 	}
 
 	// If you reach here, the word is valid
@@ -241,7 +246,12 @@ syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "ng", "0")
 	}
 	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "0", "ng")
 
-	return oldWord + " Valid: " + syllable_breakdown + isReef
+	syllable_word := " syllables"
+	syllable_count := len(strings.Split(syllable_breakdown, "-"))
+	if syllable_count == 1 {
+		syllable_word = " syllable"
+	}
+	return "**" + oldWord + "** Valid: `" + syllable_breakdown + "` with " + strconv.Itoa(syllable_count) + syllable_word + isReef
 }
 
 func IsValidNavi(word string) string {

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -220,7 +220,7 @@ func IsValidNaviHelper(word string) string {
 	}
 
 	if strings.Contains(syllable_breakdown, "-0-") || strings.Contains(syllable_breakdown, "-1-") ||
-		strings.HasPrefix(syllable_breakdown, "0-") || strings.HasPrefix(syllable_breakdown, "1-") ||
+		strings.HasPrefix(syllable_breakdown, "0") || strings.HasPrefix(syllable_breakdown, "1") ||
 		strings.HasSuffix(syllable_breakdown, "-0") || strings.HasSuffix(syllable_breakdown, "-1") {
 		return oldWord + " Psuedovowels must have onsets: " + decompress(syllable_breakdown)
 	}

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -55,7 +55,7 @@ func IsValidNaviHelper(word string) string {
 	}
 
 	if len(nonNaviLetters) > 0 {
-		return "**" + oldWord + "** Has letters not in Na'vi: " + nonNaviLetters
+		return "❌ **" + oldWord + "** Has letters not in Na'vi: " + nonNaviLetters
 	}
 
 	// Phase 1: don't confuse the digraph compression things
@@ -95,7 +95,7 @@ func IsValidNaviHelper(word string) string {
 	tempWord = strings.ReplaceAll(tempWord, "nG", "ng")
 
 	if badLetters != "" {
-		return "**" + oldWord + "** Invalid letters: `" + badLetters + "`"
+		return "❌ **" + oldWord + "** Invalid letters: `" + badLetters + "`"
 	}
 
 	// Phase 2: Compress digraphs and divide into syllable boundaries
@@ -124,7 +124,7 @@ func IsValidNaviHelper(word string) string {
 	}
 
 	if len(word_nuclei) == 0 {
-		return "**" + oldWord + "** Error: could not find any syllable nuclei"
+		return "❌ **" + oldWord + "** Error: could not find any syllable nuclei"
 	}
 
 	// Phase 2.1: Go through syllable boundaries
@@ -135,7 +135,7 @@ func IsValidNaviHelper(word string) string {
 		if b, ok := letters_map[a]; ok {
 			syllable_breakdown = syllable_breakdown + b
 		} else {
-			return "**" + oldWord + "** Invalid consonant combination: `" + strings.ToLower(decompress(a)) + "`"
+			return "❌ **" + oldWord + "** Invalid consonant combination: `" + strings.ToLower(decompress(a)) + "`"
 		}
 		if i < len(word_nuclei) {
 			syllable_breakdown = syllable_breakdown + string(word_nuclei[i])
@@ -159,7 +159,7 @@ func IsValidNaviHelper(word string) string {
 	}
 
 	if !contains[0] {
-		return "**" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
+		return "❌ **" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
 	}
 
 	if !contains[1] {
@@ -172,7 +172,7 @@ func IsValidNaviHelper(word string) string {
 		}
 
 		if !can_end_a_word {
-			return "**" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
+			return "❌ **" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
 		}
 
 		can_coda := false
@@ -185,7 +185,7 @@ func IsValidNaviHelper(word string) string {
 		}
 
 		if !can_coda {
-			return "**" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
+			return "❌ **" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
 		}
 
 		syllable_breakdown_temp := ""
@@ -203,7 +203,7 @@ func IsValidNaviHelper(word string) string {
 	// Finally, psuedovowels cannot accept codas
 	for _, a := range letters_end {
 		if a != "" && (strings.Contains(syllable_breakdown, "0"+a) || strings.Contains(syllable_breakdown, "1"+a)) {
-			return "**" + oldWord + "** Psuedovowels can't accept codas: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
+			return "❌ **" + oldWord + "** Psuedovowels can't accept codas: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
 		}
 	}
 
@@ -220,11 +220,11 @@ func IsValidNaviHelper(word string) string {
 	if strings.Contains(syllable_breakdown, "-0-") || strings.Contains(syllable_breakdown, "-1-") ||
 		strings.HasPrefix(syllable_breakdown, "0") || strings.HasPrefix(syllable_breakdown, "1") ||
 		strings.HasSuffix(syllable_breakdown, "-0") || strings.HasSuffix(syllable_breakdown, "-1") {
-		return "**" + oldWord + "** Psuedovowels must have onsets: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
+		return "❌ **" + oldWord + "** Psuedovowels must have onsets: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
 	}
 
 	if strings.Contains(syllable_breakdown, "0-r") || strings.Contains(syllable_breakdown, "1-l") {
-		return "**" + oldWord + "** Triple Rs or Ls aren't allowed: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
+		return "❌ **" + oldWord + "** Triple Rs or Ls aren't allowed: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
 	}
 
 	// If you reach here, the word is valid
@@ -252,7 +252,7 @@ func IsValidNaviHelper(word string) string {
 	if syllable_count == 1 {
 		syllable_word = " syllable"
 	}
-	return "**" + oldWord + "** Valid: `" + syllable_breakdown + "` with " + strconv.Itoa(syllable_count) + syllable_word + isReef
+	return "✅ **" + oldWord + "** Valid: `" + syllable_breakdown + "` with " + strconv.Itoa(syllable_count) + syllable_word + isReef
 }
 
 func IsValidNavi(word string) string {
@@ -279,7 +279,7 @@ func IsValidNavi(word string) string {
 	for i, a := range strings.Split(word, " ") {
 		newLine := IsValidNaviHelper(a) + "\n"
 		if len(results)+len(newLine) > 1914 {
-			results += "(stopped at " + strconv.Itoa(i+1) + ". 2000 Character limit)"
+			results += "⛔ (stopped at " + strconv.Itoa(i+1) + ". 2000 Character limit)"
 			break
 		}
 		results += newLine

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -1,0 +1,237 @@
+package fwew_lib
+
+import (
+	"strings"
+)
+
+// See if a word is phonotactically valid in Na'vi
+func IsValidNaviHelper(word string) string {
+	oldWord := word
+	// Phase 0: Clean up the word
+	word = strings.ToLower(word)
+	word = strings.Trim(word, " ")
+	// normalize tìftang character
+	word = strings.ReplaceAll(word, "’", "'")
+	word = strings.ReplaceAll(word, "‘", "'")
+	// Normalize acute accent
+	word = strings.ReplaceAll(word, "á", "a")
+	word = strings.ReplaceAll(word, "é", "e")
+	word = strings.ReplaceAll(word, "í", "i")
+	word = strings.ReplaceAll(word, "ó", "o")
+	word = strings.ReplaceAll(word, "ú", "u")
+
+	// Make sure it doesn't have any invalid letters
+	// It used unicode values to ensure it has nothing invalid
+	// We don't have to worry about uppercase letters because it handled them already
+	nonNaviLetters := ""
+	for _, a := range []rune(word) {
+		if int(a) > int(rune('ù')) {
+			nonNaviLetters += string(a)
+		} else if int(a) < int(rune('ù')) && int(a) > int(rune('ì')) {
+			nonNaviLetters += string(a)
+		} else if int(a) < int(rune('ì')) && int(a) > int(rune('ä')) {
+			nonNaviLetters += string(a)
+		} else if int(a) < int(rune('ä')) && int(a) > int(rune('z')) {
+			nonNaviLetters += string(a)
+		} else if int(a) < int(rune('a')) && int(a) > int(rune('\'')) {
+			nonNaviLetters += string(a)
+		} else if int(a) < int(rune('\'')) {
+			nonNaviLetters += string(a)
+		}
+	}
+
+	if len(nonNaviLetters) > 0 {
+		return oldWord + " Has letters not in Na'vi: " + nonNaviLetters
+	}
+
+	// Phase 1: don't confuse the digraph compression things
+	firstCheckLetters := map[rune]bool{
+		'q': true, // kx
+		'b': true, // px
+		'd': true, // tx
+		'g': true, // ng
+		'c': true, // ts
+		'0': true, // rr
+		'1': true, // ll
+		'2': true, // aw
+		'3': true, // ay
+		'4': true, // ew
+		'5': true, // ey
+	}
+
+	badLetters := ""
+	for i, a := range []rune(word) {
+		// G is allowed as part of "ng"
+		if a == 'g' {
+			if !(i > 0 && []rune(word)[i-1] == 'n') {
+				badLetters = badLetters + string(a)
+			}
+			continue
+		}
+		if _, ok := firstCheckLetters[a]; ok {
+			badLetters = badLetters + string(a)
+		}
+	}
+
+	if badLetters != "" {
+		return oldWord + " Invalid letters: " + badLetters
+	}
+
+	// Phase 2: Compress digraphs and divide into syllable boundaries
+	compressed := compress(word)
+	nuclei := []rune{
+		'a', 'ä', 'e', 'i', 'ì', 'o', 'u', 'ù', // vowels
+		'0', '1', '2', '3', '4', '5', // diphthongs and psuedovowels
+	}
+	psuedovowels := []bool{}
+
+	syllable_boundaries := ""
+	word_nuclei := []rune{}
+	for _, a := range []rune(compressed) {
+		found := false
+		for _, b := range nuclei {
+			if a == b {
+				found = true
+				if a == '0' || a == '1' {
+					psuedovowels = append(psuedovowels, true)
+				} else {
+					psuedovowels = append(psuedovowels, false)
+				}
+				word_nuclei = append(word_nuclei, a)
+				break
+			}
+		}
+		if !found {
+			syllable_boundaries = syllable_boundaries + string(a)
+		} else {
+			syllable_boundaries = syllable_boundaries + " ."
+		}
+	}
+
+	if len(word_nuclei) == 0 {
+		return "Error: could not find any syllable nuclei in " + oldWord
+	}
+
+	// Phase 2.1: Go through syllable boundaries
+	cluster_1 := []string{"f", "s", "c"}
+	cluster_2 := []string{"k", "q", "l", "m", "n", "g", "p",
+		"b", "t", "d", "r", "w", "y"}
+	letters_start := []string{"", "p", "t", "k", "b", "d", "q", "'",
+		"m", "n", "g", "r", "l", "w", "y",
+		"f", "v", "s", "z", "c", "h"}
+	letters_end := []string{"", "p", "t", "k", "b", "d", "q", "'",
+		"m", "n", "l", "r", "g"}
+
+	letters_map := map[string]string{}
+	for _, a := range letters_end {
+		for _, b := range letters_start {
+			// Do not assume a thing comes at the end of a word if it doesn't have to
+			if !(a != "" && b == "") {
+				letters_map[a+b] = a + "-" + b
+			}
+		}
+		for _, b := range cluster_1 {
+			for _, c := range cluster_2 {
+				// Do not assume a thing comes at the end of a word if it doesn't have to
+				if !(a != "" && b == "") {
+					letters_map[a+b+c] = a + "-" + b + c
+				}
+			}
+		}
+	}
+
+	syllable_breakdown := ""
+
+	for i, a := range strings.Split(syllable_boundaries, ".") {
+		a = strings.ReplaceAll(a, " ", "")
+		if b, ok := letters_map[a]; ok {
+			syllable_breakdown = syllable_breakdown + b
+		} else {
+			return oldWord + " Invalid consonants: \"" + decompress(a) + "\""
+		}
+		if i < len(word_nuclei) {
+			syllable_breakdown = syllable_breakdown + string(word_nuclei[i])
+		}
+	}
+
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, " ", "")
+	syllable_breakdown = strings.TrimPrefix(syllable_breakdown, "-")
+	syllable_breakdown = strings.TrimSuffix(syllable_breakdown, "-")
+
+	// Phase 3: Clean up the word and do final checks
+	syllables := strings.Split(syllable_breakdown, "-")
+	contains := []bool{false, false}
+	for _, a := range nuclei {
+		if strings.Contains(syllables[0], string(a)) {
+			contains[0] = true
+		}
+		if strings.Contains(syllables[len(syllables)-1], string(a)) {
+			contains[1] = true
+		}
+	}
+
+	if !contains[0] {
+		return oldWord + " Incomplete syllables: \"" + decompress(syllable_breakdown) + "\""
+	}
+
+	if !contains[1] {
+		can_end_a_word := false
+		for _, a := range letters_end {
+			if syllables[len(syllables)-1] == string(a) {
+				can_end_a_word = true
+				break
+			}
+		}
+
+		if !can_end_a_word {
+			return oldWord + " Incomplete syllables: \"" + decompress(syllable_breakdown) + "\""
+		}
+
+		can_coda := false
+
+		for _, a := range nuclei {
+			if strings.HasSuffix(syllables[len(syllables)-2], string(a)) {
+				can_coda = true
+				break
+			}
+		}
+
+		if !can_coda {
+			return oldWord + " Incomplete syllables: \"" + decompress(syllable_breakdown) + "\""
+		}
+
+		syllable_breakdown_temp := ""
+
+		for i, a := range syllables {
+			if i != len(syllables)-1 {
+				syllable_breakdown_temp += "-"
+			}
+			syllable_breakdown_temp += a
+		}
+
+		syllable_breakdown = strings.TrimPrefix(syllable_breakdown_temp, "-")
+	}
+
+	// Finally, psuedovowels cannot accept codas
+	for _, a := range letters_end {
+		if a != "" && (strings.Contains(syllable_breakdown, "0"+a) || strings.Contains(syllable_breakdown, "1"+a)) {
+			return oldWord + " Psuedovowels can't accept codas: " + decompress(syllable_breakdown)
+		}
+	}
+
+	if strings.Contains(syllable_breakdown, "-0-") || strings.Contains(syllable_breakdown, "-1-") ||
+		strings.HasPrefix(syllable_breakdown, "0-") || strings.HasPrefix(syllable_breakdown, "1-") ||
+		strings.HasSuffix(syllable_breakdown, "-0") || strings.HasSuffix(syllable_breakdown, "-1") {
+		return oldWord + " Psuedovowels must have onsets: " + decompress(syllable_breakdown)
+	}
+
+	return oldWord + " Valid: " + decompress(syllable_breakdown)
+}
+
+func IsValidNavi(word string) string {
+	results := ""
+	for _, a := range strings.Split(word, " ") {
+		results += IsValidNaviHelper(a) + "\n"
+	}
+	return results
+}

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -231,12 +231,15 @@ func IsValidNaviHelper(word string) string {
 	// If you reach here, the word is valid
 	syllable_breakdown = strings.ToLower(decompress(syllable_breakdown))
 
+syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "ng", "0")
+
 	isReef := ""
 	if strings.ContainsAny(syllable_breakdown, "bdg") || strings.Contains(oldWord, "ch") || strings.Contains(oldWord, "sh") {
 		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "tsy", "ch")
 		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "sy", "sh")
 		isReef = " (in reef dialect)"
 	}
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "ng", "0")
 
 	return oldWord + " Valid: " + syllable_breakdown + isReef
 }

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -223,6 +223,16 @@ func IsValidNaviHelper(word string) string {
 		}
 	}
 
+	// Ensure no diphthong confuses the checker (as in "ewll" becoming "ew-ll" and not "e-wll")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "2-0", "a-w0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "2-1", "a-w1")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "3-0", "a-y0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "3-1", "a-y1")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "4-0", "e-w0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "4-1", "e-w1")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "5-0", "e-y0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "5-1", "e-y1")
+
 	if strings.Contains(syllable_breakdown, "-0-") || strings.Contains(syllable_breakdown, "-1-") ||
 		strings.HasPrefix(syllable_breakdown, "0") || strings.HasPrefix(syllable_breakdown, "1") ||
 		strings.HasSuffix(syllable_breakdown, "-0") || strings.HasSuffix(syllable_breakdown, "-1") {
@@ -245,6 +255,13 @@ func IsValidNaviHelper(word string) string {
 		isReef = " (in reef dialect)"
 	}
 	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "0", "ng")
+
+	// Double diphthongs are usually not genuine in Na'vi
+	// For example, mawey is ma-wey (not maw-ey) and kxeyey is kxe-yey (not kxey-ey)
+	for _, a := range []rune{'a', 'ä', 'e', 'i', 'ì', 'o', 'u', 'ù'} {
+		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "w-"+string(a), "-w"+string(a))
+		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "y-"+string(a), "-y"+string(a))
+	}
 
 	syllable_word := " syllables"
 	syllable_count := len(strings.Split(syllable_breakdown, "-"))

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -273,8 +273,13 @@ func IsValidNaviHelper(word string) string {
 
 func IsValidNavi(word string) string {
 	results := ""
-	for _, a := range strings.Split(word, " ") {
-		results += IsValidNaviHelper(a) + "\n"
+	for i, a := range strings.Split(word, " ") {
+		newLine := IsValidNaviHelper(a) + "\n"
+		if len(results)+len(newLine) > 1914 {
+			results += "(stopped at " + strconv.Itoa(i+1) + ". 2000 Character limit)"
+			break
+		}
+		results += newLine
 	}
 	return results
 }

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -19,6 +19,8 @@ func IsValidNaviHelper(word string) string {
 	word = strings.ReplaceAll(word, "í", "i")
 	word = strings.ReplaceAll(word, "ó", "o")
 	word = strings.ReplaceAll(word, "ú", "u")
+	word = strings.ReplaceAll(word, "ch", "tsy")
+	word = strings.ReplaceAll(word, "sh", "sy")
 
 	// Make sure it doesn't have any invalid letters
 	// It used unicode values to ensure it has nothing invalid
@@ -226,7 +228,17 @@ func IsValidNaviHelper(word string) string {
 		return oldWord + " Psuedovowels must have onsets: " + decompress(strings.ToLower(syllable_breakdown))
 	}
 
-	return oldWord + " Valid: " + decompress(strings.ToLower(syllable_breakdown))
+	// If you reach here, the word is valid
+	syllable_breakdown = strings.ToLower(decompress(syllable_breakdown))
+
+	isReef := ""
+	if strings.ContainsAny(syllable_breakdown, "bdg") || strings.Contains(oldWord, "ch") || strings.Contains(oldWord, "sh") {
+		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "tsy", "ch")
+		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "sy", "sh")
+		isReef = " (in reef dialect)"
+	}
+
+	return oldWord + " Valid: " + syllable_breakdown + isReef
 }
 
 func IsValidNavi(word string) string {

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -236,7 +236,7 @@ func IsValidNaviHelper(word string) string {
 	// If you reach here, the word is valid
 	syllable_breakdown = strings.ToLower(decompress(syllable_breakdown))
 
-syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "ng", "0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "ng", "0")
 
 	isReef := ""
 	if strings.ContainsAny(syllable_breakdown, "bdg") || strings.Contains(oldWord, "ch") || strings.Contains(oldWord, "sh") {


### PR DESCRIPTION
- When searching for a word that has a dictionary entry but is or looks like a productive compound, the exact match comes first now (nìmip, kilvan, kìmar, etc.)
- Added a `/valid` command to determine whether or not a word would be valid as a Na'vi word, including whether or not it looks like a reef dialect word and what is wrong with the word (if anything)
- Added an `/oddball` command to show all (3 of) the Na'vi words that seemingly violate Na'vi phonotactics (jakesully, oìsss, oìsss si)
- Added `-ya` as a productive suffix for nouns