### PR TITLE
Recognize more conjugations of words

### DIFF
--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -672,6 +672,25 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 	for _, candidate := range conjugations {
 		a := strings.ReplaceAll(candidate.word, "ù", "u")
 		for _, c := range dictHash[a] {
+			// An inter. can act like a noun or an adjective, so it gets special treatment
+			if c.PartOfSpeech == "inter." && len(c.Affixes.Infix) == 0 {
+				dupe := false
+				for _, b := range results {
+					if b.Navi == c.Navi {
+						dupe = true
+						break
+					}
+				}
+				if !dupe {
+					a := c
+					a.Affixes.Lenition = candidate.lenition
+					a.Affixes.Prefix = candidate.prefixes
+					a.Affixes.Infix = candidate.infixes
+					a.Affixes.Suffix = candidate.suffixes
+					results = AppendAndAlphabetize(results, a)
+					continue
+				}
+			}
 
 			// Find gerunds (tì-v<us>erb, treated like a noun)
 			gerund := false

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -197,7 +197,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 	}
 	newString := ""
 
-	if input.insistPOS == "adj." || input.insistPOS == "any" {
+	if input.insistPOS == "n." || input.insistPOS == "any" {
 		// For [word] si becoming [word]tswo
 		if strings.HasSuffix(input.word, "tswo") {
 			newCandidate := candidateDupe(input)
@@ -207,17 +207,10 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			if !isDuplicate(newCandidate) {
 				candidates = append(candidates, newCandidate)
 			}
-		} else if strings.HasSuffix(input.word, "tswoa") {
-			newCandidate := candidateDupe(input)
-			newCandidate.word = strings.TrimSuffix(input.word, "tswoa") + " si"
-			newCandidate.insistPOS = "v."
-			newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "tswo")
-			newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "a")
-			if !isDuplicate(newCandidate) {
-				candidates = append(candidates, newCandidate)
-			}
 		}
+	}
 
+	if input.insistPOS == "adj." || input.insistPOS == "any" {
 		// For lrrtok-susi and others
 		if strings.HasSuffix(input.word, "-susi") || strings.HasSuffix(input.word, "-susia") {
 			found := false

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -454,36 +454,36 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 					newCandidate.insistPOS = "n."
 					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
 					// all set to 2 to avoid mengeyä -> mengo -> me + 'eng + o
-					deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+					deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, false)
 
 					if oldSuffix == "ä" && !strings.HasSuffix(input.word, "yä") && strings.HasSuffix(input.word, "iä") { // Don't make peyä -> yä -> ya (air)
 						// soaiä, tìftiä, etx.
 						newString += "a"
 						newCandidate.word = newString
-						deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+						deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, false)
 					} else if oldSuffix == "yä" && strings.HasSuffix(newString, "e") {
 						// A one-off
 						if newString == "tse" {
 							newCandidate.word = "tsaw"
-							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+							deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, false)
 						}
 						// ngeyä -> nga
 						newCandidate.word = strings.TrimSuffix(newString, "e") + "a"
-						deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+						deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, false)
 						// oengeyä
 						newCandidate.word = strings.TrimSuffix(newString, "e")
 						if newCandidate.word == "oeng" { //no mengeyä -> meng -> me + 'eng
-							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+							deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, false)
 						}
 						// sneyä -> sno
 						newCandidate.word = strings.TrimSuffix(newString, "e") + "o"
-						deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+						deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, false)
 					} else if vowel, ok := vowelSuffixes[oldSuffix]; ok {
 						// Make sure zekwä-äo is recognized
 						if strings.HasSuffix(newString, vowel+"-") {
 							newString = strings.TrimSuffix(newString, "-")
 							newCandidate.word = newString
-							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+							deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, false)
 						}
 					}
 				}

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -167,6 +167,10 @@ func infixError(query string, didYouMean string, ipa string) Word {
 }
 
 func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck int, unlenite int8, checkInfixes bool) []ConjugationCandidate {
+	if isDuplicate(input) {
+		return candidates
+	}
+
 	// Exceptions for how words conjugate
 	if len(input.suffixes) == 1 {
 		if input.word == "tsa" {
@@ -188,6 +192,11 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 		}
 	}
 
+	if !isDuplicate(input) {
+		candidates = append(candidates, input)
+	}
+	newString := ""
+
 	if input.insistPOS == "adj." || input.insistPOS == "any" {
 		// For [word] si becoming [word]tswo
 		if strings.HasSuffix(input.word, "tswo") {
@@ -195,14 +204,18 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			newCandidate.word = strings.TrimSuffix(input.word, "tswo") + " si"
 			newCandidate.insistPOS = "v."
 			newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "tswo")
-			candidates = append(candidates, newCandidate)
+			if !isDuplicate(newCandidate) {
+				candidates = append(candidates, newCandidate)
+			}
 		} else if strings.HasSuffix(input.word, "tswoa") {
 			newCandidate := candidateDupe(input)
 			newCandidate.word = strings.TrimSuffix(input.word, "tswoa") + " si"
 			newCandidate.insistPOS = "v."
 			newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "tswo")
 			newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "a")
-			candidates = append(candidates, newCandidate)
+			if !isDuplicate(newCandidate) {
+				candidates = append(candidates, newCandidate)
+			}
 		}
 
 		// For lrrtok-susi and others
@@ -243,7 +256,9 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 				}
 			}
 
-			candidates = append(candidates, input) // to bump the real candidate into recognition
+			if !isDuplicate(input) {
+				candidates = append(candidates, input)
+			} // to bump the real candidate into recognition
 
 			if found {
 				newCandidate := candidateDupe(input)
@@ -257,404 +272,399 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 				if aPosition == 1 {
 					newCandidate.suffixes = append(newCandidate.suffixes, "a")
 				}
-				if !isDuplicate(input) {
+				if !isDuplicate(newCandidate) {
 					candidates = append(candidates, newCandidate)
 				}
 			}
 			return candidates
 		}
 	}
-	if !isDuplicate(input) {
-		candidates = append(candidates, input)
-		newString := ""
 
-		// Make sure that the first set of prefices (a, nì, ke) aren't combined with suffixes
-		newPrefixCheck := prefixCheck
-		if newPrefixCheck == 0 {
-			newPrefixCheck = 1
+	// Make sure that the first set of prefices (a, nì, ke) aren't combined with suffixes
+	newPrefixCheck := prefixCheck
+	if newPrefixCheck == 0 {
+		newPrefixCheck = 1
+	}
+
+	switch prefixCheck {
+	case 0:
+		if strings.HasPrefix(input.word, "a") && input.insistPOS != "n." && !strings.HasPrefix(input.insistPOS, "ad") {
+			// No nouns, adpositions or adverbs
+			newCandidate := candidateDupe(input)
+			newCandidate.word = input.word[1:]
+			newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "a")
+			newCandidate.insistPOS = "adj."
+			deconjugateHelper(newCandidate, 1, suffixCheck, -1, false)
+			newCandidate.insistPOS = "v."
+			deconjugateHelper(newCandidate, 1, suffixCheck, -1, true)
+		} else if strings.HasPrefix(input.word, "nì") {
+			newCandidate := candidateDupe(input)
+			newCandidate.word = strings.TrimPrefix(input.word, "nì")
+			newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "nì")
+			newCandidate.insistPOS = "nì."
+			// No other affixes allowed
+			deconjugateHelper(newCandidate, 10, 10, -1, false) // No other fixes
 		}
-
-		switch prefixCheck {
-		case 0:
-			if strings.HasPrefix(input.word, "a") && input.insistPOS != "n." && !strings.HasPrefix(input.insistPOS, "ad") {
-				// No nouns, adpositions or adverbs
+		fallthrough
+	case 1:
+		for _, element := range verbPrefixes {
+			// If it has a prefix
+			if strings.HasPrefix(input.word, element) {
+				// remove it
 				newCandidate := candidateDupe(input)
-				newCandidate.word = input.word[1:]
-				newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "a")
-				newCandidate.insistPOS = "adj."
-				deconjugateHelper(newCandidate, 1, suffixCheck, -1, false)
+				newCandidate.word = strings.TrimPrefix(input.word, element)
 				newCandidate.insistPOS = "v."
-				deconjugateHelper(newCandidate, 1, suffixCheck, -1, true)
-			} else if strings.HasPrefix(input.word, "nì") {
-				newCandidate := candidateDupe(input)
-				newCandidate.word = strings.TrimPrefix(input.word, "nì")
-				newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "nì")
-				newCandidate.insistPOS = "nì."
-				// No other affixes allowed
-				deconjugateHelper(newCandidate, 10, 10, -1, false) // No other fixes
+				newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
+				deconjugateHelper(newCandidate, 10, 10, -1, false)
+
+				// check "tsatan", "tan" and "atan"
+				newCandidate.word = get_last_rune(element, 1) + newCandidate.word
+				deconjugateHelper(newCandidate, 10, 10, -1, false)
 			}
-			fallthrough
-		case 1:
-			for _, element := range verbPrefixes {
+		}
+		fallthrough
+	case 2:
+		// Non-lenition prefixes for nouns only
+		if input.insistPOS == "any" || input.insistPOS == "n." {
+			for _, element := range prefixes1Nouns {
+				// If it has a prefix
+				if strings.HasPrefix(input.word, element) {
+					// remove it
+					newString = strings.TrimPrefix(input.word, element)
+
+					newCandidate := candidateDupe(input)
+					newCandidate.word = newString
+					newCandidate.insistPOS = "n."
+					newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
+					deconjugateHelper(newCandidate, 3, suffixCheck, -1, false)
+
+					// check "tsatan", "tan" and "atan"
+					newCandidate.word = get_last_rune(element, 1) + newString
+					deconjugateHelper(newCandidate, 3, suffixCheck, -1, false)
+				}
+			}
+		}
+		fallthrough
+	case 3:
+		if input.insistPOS == "any" || input.insistPOS == "n." {
+			// This one will demand this makes it use lenition
+			for _, element := range prefixes1lenition {
+				// If it has a lenition-causing prefix
+				if strings.HasPrefix(input.word, element) {
+					lenited := false
+					newString = strings.TrimPrefix(input.word, element)
+
+					newCandidate := candidateDupe(input)
+					newCandidate.word = newString
+					newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
+					newCandidate.insistPOS = "n."
+
+					// Could it be pekoyu (pe + 'ekoyu, not pe + kxoyu)
+					if has("aäeiìou", get_last_rune(element, 1)) {
+						// check "pxeyktan", "yktan" and "eyktan"
+						newCandidate.word = get_last_rune(element, 1) + newString
+						deconjugateHelper(newCandidate, 4, suffixCheck, -1, false)
+
+						// check "pxeylan", "ylan" and "'eylan"
+						newCandidate.word = "'" + newCandidate.word
+						deconjugateHelper(newCandidate, 4, suffixCheck, -1, false)
+					}
+
+					// find out the possible unlenited forms
+					for _, oldPrefix := range unlenitionLetters {
+						// If it has a letter that could have changed for lenition,
+						if strings.HasPrefix(newString, oldPrefix) {
+							// put all possibilities in the candidates
+							lenited = true
+
+							for _, newPrefix := range unlenition[oldPrefix] {
+								newCandidate.word = newPrefix + strings.TrimPrefix(newString, oldPrefix)
+								if oldPrefix != newPrefix {
+									newCandidate.lenition = []string{newPrefix + "→" + oldPrefix}
+								}
+								deconjugateHelper(newCandidate, 4, suffixCheck, -1, false)
+							}
+							break // We don't want the "ts" to become "txs"
+						}
+					}
+					if !lenited {
+						newCandidate.word = newString
+						deconjugateHelper(newCandidate, 3, suffixCheck, -1, false)
+					}
+				}
+			}
+		}
+		fallthrough
+	case 4:
+		if input.insistPOS == "any" || input.insistPOS == "n." {
+			for _, element := range stemPrefixes {
 				// If it has a prefix
 				if strings.HasPrefix(input.word, element) {
 					// remove it
 					newCandidate := candidateDupe(input)
 					newCandidate.word = strings.TrimPrefix(input.word, element)
-					newCandidate.insistPOS = "v."
+					newCandidate.insistPOS = "n."
 					newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
-					deconjugateHelper(newCandidate, 10, 10, -1, false)
+					deconjugateHelper(newCandidate, 5, suffixCheck, -1, false)
 
 					// check "tsatan", "tan" and "atan"
 					newCandidate.word = get_last_rune(element, 1) + newCandidate.word
-					deconjugateHelper(newCandidate, 10, 10, -1, false)
-				}
-			}
-			fallthrough
-		case 2:
-			// Non-lenition prefixes for nouns only
-			if input.insistPOS == "any" || input.insistPOS == "n." {
-				for _, element := range prefixes1Nouns {
-					// If it has a prefix
-					if strings.HasPrefix(input.word, element) {
-						// remove it
-						newString = strings.TrimPrefix(input.word, element)
-
-						newCandidate := candidateDupe(input)
-						newCandidate.word = newString
-						newCandidate.insistPOS = "n."
-						newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
-						deconjugateHelper(newCandidate, 3, suffixCheck, -1, false)
-
-						// check "tsatan", "tan" and "atan"
-						newCandidate.word = get_last_rune(element, 1) + newString
-						deconjugateHelper(newCandidate, 3, suffixCheck, -1, false)
-					}
-				}
-			}
-			fallthrough
-		case 3:
-			if input.insistPOS == "any" || input.insistPOS == "n." {
-				// This one will demand this makes it use lenition
-				for _, element := range prefixes1lenition {
-					// If it has a lenition-causing prefix
-					if strings.HasPrefix(input.word, element) {
-						lenited := false
-						newString = strings.TrimPrefix(input.word, element)
-
-						newCandidate := candidateDupe(input)
-						newCandidate.word = newString
-						newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
-						newCandidate.insistPOS = "n."
-
-						// Could it be pekoyu (pe + 'ekoyu, not pe + kxoyu)
-						if has("aäeiìou", get_last_rune(element, 1)) {
-							// check "pxeyktan", "yktan" and "eyktan"
-							newCandidate.word = get_last_rune(element, 1) + newString
-							deconjugateHelper(newCandidate, 4, suffixCheck, -1, false)
-
-							// check "pxeylan", "ylan" and "'eylan"
-							newCandidate.word = "'" + newCandidate.word
-							deconjugateHelper(newCandidate, 4, suffixCheck, -1, false)
-						}
-
-						// find out the possible unlenited forms
-						for _, oldPrefix := range unlenitionLetters {
-							// If it has a letter that could have changed for lenition,
-							if strings.HasPrefix(newString, oldPrefix) {
-								// put all possibilities in the candidates
-								lenited = true
-
-								for _, newPrefix := range unlenition[oldPrefix] {
-									newCandidate.word = newPrefix + strings.TrimPrefix(newString, oldPrefix)
-									if oldPrefix != newPrefix {
-										newCandidate.lenition = []string{newPrefix + "→" + oldPrefix}
-									}
-									deconjugateHelper(newCandidate, 4, suffixCheck, -1, false)
-								}
-								break // We don't want the "ts" to become "txs"
-							}
-						}
-						if !lenited {
-							newCandidate.word = newString
-							deconjugateHelper(newCandidate, 3, suffixCheck, -1, false)
-						}
-					}
-				}
-			}
-			fallthrough
-		case 4:
-			if input.insistPOS == "any" || input.insistPOS == "n." {
-				for _, element := range stemPrefixes {
-					// If it has a prefix
-					if strings.HasPrefix(input.word, element) {
-						// remove it
-						newCandidate := candidateDupe(input)
-						newCandidate.word = strings.TrimPrefix(input.word, element)
-						newCandidate.insistPOS = "n."
-						newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
-						deconjugateHelper(newCandidate, 5, suffixCheck, -1, false)
-
-						// check "tsatan", "tan" and "atan"
-						newCandidate.word = get_last_rune(element, 1) + newCandidate.word
-						deconjugateHelper(newCandidate, 5, suffixCheck, -1, false)
-					}
-				}
-			}
-			fallthrough
-		case 5:
-			if strings.HasPrefix(input.word, "tì") {
-				if input.insistPOS == "any" || input.insistPOS == "n." {
-					// remove it
-					newCandidate := candidateDupe(input)
-					newCandidate.word = strings.TrimPrefix(input.word, "tì")
-					newCandidate.insistPOS = "v."
-					newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "tì")
-					deconjugateHelper(newCandidate, 10, 10, -1, true) // No other prefixes allowed
-
-					newCandidate.word = "ì" + newCandidate.word
-					deconjugateHelper(newCandidate, 10, 10, -1, true) // Or any additional suffixes
+					deconjugateHelper(newCandidate, 5, suffixCheck, -1, false)
 				}
 			}
 		}
-
-		switch suffixCheck {
-		case 0:
-			// Reserved in case "pe" after a case ending is grammatical
-			// special case: short genitives of pronouns like "oey" and "ngey"
+		fallthrough
+	case 5:
+		if strings.HasPrefix(input.word, "tì") {
 			if input.insistPOS == "any" || input.insistPOS == "n." {
-				if strings.HasSuffix(input.word, "y") {
-					// oey to oe
-					newCandidate := candidateDupe(input)
-					newCandidate.word = strings.TrimSuffix(input.word, "y")
-					newCandidate.insistPOS = "pn."
-					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "y")
-					deconjugateHelper(newCandidate, newPrefixCheck, 10, unlenite, false)
-
-					// ngey to nga
-					if strings.HasSuffix(newCandidate.word, "e") {
-						newCandidate.word = strings.TrimSuffix(newCandidate.word, "e") + "a"
-						newCandidate.insistPOS = "pn."
-						deconjugateHelper(newCandidate, newPrefixCheck, 10, unlenite, false)
-					}
-				}
-
-				for _, oldSuffix := range adposuffixes {
-					// If it has one of them,
-					if strings.HasSuffix(input.word, oldSuffix) {
-						newString = strings.TrimSuffix(input.word, oldSuffix)
-
-						newCandidate := candidateDupe(input)
-						newCandidate.word = newString
-						newCandidate.insistPOS = "n."
-						newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
-						// all set to 2 to avoid mengeyä -> mengo -> me + 'eng + o
-						deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
-
-						if oldSuffix == "ä" && !strings.HasSuffix(input.word, "yä") && strings.HasSuffix(input.word, "iä") { // Don't make peyä -> yä -> ya (air)
-							// soaiä, tìftiä, etx.
-							newString += "a"
-							newCandidate.word = newString
-							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
-						} else if oldSuffix == "yä" && strings.HasSuffix(newString, "e") {
-							// A one-off
-							if newString == "tse" {
-								newCandidate.word = "tsaw"
-								deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
-							}
-							// ngeyä -> nga
-							newCandidate.word = strings.TrimSuffix(newString, "e") + "a"
-							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
-							// oengeyä
-							newCandidate.word = strings.TrimSuffix(newString, "e")
-							if newCandidate.word == "oeng" { //no mengeyä -> meng -> me + 'eng
-								deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
-							}
-							// sneyä -> sno
-							newCandidate.word = strings.TrimSuffix(newString, "e") + "o"
-							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
-						} else if vowel, ok := vowelSuffixes[oldSuffix]; ok {
-							// Make sure zekwä-äo is recognized
-							if strings.HasSuffix(newString, vowel+"-") {
-								newString = strings.TrimSuffix(newString, "-")
-								newCandidate.word = newString
-								deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
-							}
-						}
-					}
-				}
-			}
-			fallthrough
-		case 1: // adpositions, sì, o, case endings
-			if input.insistPOS == "any" || input.insistPOS == "n." {
-				if strings.HasSuffix(input.word, "pe") {
-					newString = strings.TrimSuffix(input.word, "pe")
-
-					newCandidate := candidateDupe(input)
-					newCandidate.word = newString
-					newCandidate.insistPOS = "n."
-					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "pe")
-					deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
-				}
-			}
-			fallthrough
-		case 2:
-			// If it has one of them,
-			if strings.HasSuffix(input.word, "a") && input.insistPOS != "n." && !strings.HasPrefix(input.insistPOS, "ad") {
-				// No nouns, adpositions or adverbs
-				newString = strings.TrimSuffix(input.word, "a")
-
+				// remove it
 				newCandidate := candidateDupe(input)
-				newCandidate.word = newString
-				newCandidate.insistPOS = "adj."
-				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "a")
-				deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, true)
+				newCandidate.word = strings.TrimPrefix(input.word, "tì")
 				newCandidate.insistPOS = "v."
-				deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, true)
+				newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "tì")
+				deconjugateHelper(newCandidate, 10, 10, -1, true) // No other prefixes allowed
+
+				newCandidate.word = "ì" + newCandidate.word
+				deconjugateHelper(newCandidate, 10, 10, -1, true) // Or any additional suffixes
 			}
-			for _, oldSuffix := range lastSuffixes {
+		}
+	}
+
+	switch suffixCheck {
+	case 0:
+		// Reserved in case "pe" after a case ending is grammatical
+		// special case: short genitives of pronouns like "oey" and "ngey"
+		if input.insistPOS == "any" || input.insistPOS == "n." {
+			if strings.HasSuffix(input.word, "y") {
+				// oey to oe
+				newCandidate := candidateDupe(input)
+				newCandidate.word = strings.TrimSuffix(input.word, "y")
+				newCandidate.insistPOS = "pn."
+				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "y")
+				deconjugateHelper(newCandidate, newPrefixCheck, 10, unlenite, false)
+
+				// ngey to nga
+				if strings.HasSuffix(newCandidate.word, "e") {
+					newCandidate.word = strings.TrimSuffix(newCandidate.word, "e") + "a"
+					newCandidate.insistPOS = "pn."
+					deconjugateHelper(newCandidate, newPrefixCheck, 10, unlenite, false)
+				}
+			}
+
+			for _, oldSuffix := range adposuffixes {
 				// If it has one of them,
 				if strings.HasSuffix(input.word, oldSuffix) {
 					newString = strings.TrimSuffix(input.word, oldSuffix)
 
 					newCandidate := candidateDupe(input)
 					newCandidate.word = newString
-					newCandidate.insistPOS = "any"
-					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
-					deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, true)
-				}
-			}
-
-			fallthrough
-		case 3: // -o suffix "some"
-			if input.insistPOS == "any" || input.insistPOS == "n." {
-				if strings.HasSuffix(input.word, "o") {
-					newString = strings.TrimSuffix(input.word, "o")
-
-					newCandidate := candidateDupe(input)
-					newCandidate.word = newString
 					newCandidate.insistPOS = "n."
-					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "o")
-					deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, false)
+					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
+					// all set to 2 to avoid mengeyä -> mengo -> me + 'eng + o
+					deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
 
-					// Make sure fya'o-o is recognized
-					if vowel, ok := vowelSuffixes["o"]; ok {
-						// Make sure fya'o-o is recognized
+					if oldSuffix == "ä" && !strings.HasSuffix(input.word, "yä") && strings.HasSuffix(input.word, "iä") { // Don't make peyä -> yä -> ya (air)
+						// soaiä, tìftiä, etx.
+						newString += "a"
+						newCandidate.word = newString
+						deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+					} else if oldSuffix == "yä" && strings.HasSuffix(newString, "e") {
+						// A one-off
+						if newString == "tse" {
+							newCandidate.word = "tsaw"
+							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+						}
+						// ngeyä -> nga
+						newCandidate.word = strings.TrimSuffix(newString, "e") + "a"
+						deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+						// oengeyä
+						newCandidate.word = strings.TrimSuffix(newString, "e")
+						if newCandidate.word == "oeng" { //no mengeyä -> meng -> me + 'eng
+							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+						}
+						// sneyä -> sno
+						newCandidate.word = strings.TrimSuffix(newString, "e") + "o"
+						deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+					} else if vowel, ok := vowelSuffixes[oldSuffix]; ok {
+						// Make sure zekwä-äo is recognized
 						if strings.HasSuffix(newString, vowel+"-") {
 							newString = strings.TrimSuffix(newString, "-")
 							newCandidate.word = newString
-							deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, false)
+							deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
 						}
-					}
-				}
-			}
-			fallthrough
-		case 4:
-			// If it has one of them,
-			if input.insistPOS == "any" || input.insistPOS == "n." {
-				// verb suffixes change things from verbs to nouns, that's why we check for noun status
-				for _, oldSuffix := range verbSuffixes {
-					// If it has one of them,
-					if strings.HasSuffix(input.word, oldSuffix) {
-						newString = strings.TrimSuffix(input.word, oldSuffix)
-						newCandidate := candidateDupe(input)
-						newCandidate.word = newString
-						newCandidate.insistPOS = "v."
-
-						newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
-						deconjugateHelper(newCandidate, 10, 10, unlenite, false) // Don't allow any other prefixes
-						// They may turn the insistPOS back into a noun
-
-						if oldSuffix == "yu" && strings.HasSuffix(newString, "si") {
-							newCandidate.word = strings.TrimSuffix(newString, "si") + " si"
-							deconjugateHelper(newCandidate, 10, 10, unlenite, false) // don't allow any other prefixes or suffixes
-						}
-					}
-				}
-			}
-			fallthrough
-		case 5:
-			if input.insistPOS == "any" || input.insistPOS == "n." {
-				for _, oldSuffix := range stemSuffixes {
-					// If it has one of them,
-					if strings.HasSuffix(input.word, oldSuffix) {
-						newString = strings.TrimSuffix(input.word, oldSuffix)
-
-						//candidates = append(candidates, newString)
-						newCandidate := candidateDupe(input)
-						newCandidate.word = newString
-						newCandidate.insistPOS = "n."
-						newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
-						deconjugateHelper(newCandidate, newPrefixCheck, 6, unlenite, false)
 					}
 				}
 			}
 		}
+		fallthrough
+	case 1: // adpositions, sì, o, case endings
+		if input.insistPOS == "any" || input.insistPOS == "n." {
+			if strings.HasSuffix(input.word, "pe") {
+				newString = strings.TrimSuffix(input.word, "pe")
 
-		// Short lenition check
-		if unlenite != -1 {
-			for _, oldPrefix := range unlenitionLetters {
-				// If it has a letter that could have changed for lenition,
-				if strings.HasPrefix(input.word, oldPrefix) {
-					// put all possibilities in the candidates
-					for _, newPrefix := range unlenition[oldPrefix] {
-						newCandidate := candidateDupe(input)
-						newString = newPrefix + strings.TrimPrefix(input.word, oldPrefix)
-						newCandidate.word = newString
-						if oldPrefix != newPrefix {
-							newCandidate.lenition = []string{newPrefix + "→" + oldPrefix}
-						}
-						deconjugateHelper(newCandidate, prefixCheck, suffixCheck, -1, false)
-					}
-					break // We don't want the "ts" to become "txs"
-				}
-			}
-		}
-
-		if checkInfixes {
-			// Maybe someone else came in with stripped infixes
-			if len(input.word) > 2 && input.word[len(input.word)-3] != ' ' && strings.HasSuffix(input.word, "si") && input.word != "susi" && input.word != "satsi" {
 				newCandidate := candidateDupe(input)
-				newCandidate.word = strings.TrimSuffix(input.word, "si") + " si"
-				newCandidate.insistPOS = "v."
-				deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true)
-			} else { // If there is a "si", we don't need to check for infixes
-				// Check for infixes
-				runes := []rune(input.word)
-				for i, c := range runes {
-					// Infixes can only begin with vowels
-					if has("aäeiìou", string(c)) {
-						shortString := string(runes[i:])
-						for _, infix := range infixes[c] {
-							if strings.HasPrefix(shortString, infix) {
+				newCandidate.word = newString
+				newCandidate.insistPOS = "n."
+				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "pe")
+				deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, false)
+			}
+		}
+		fallthrough
+	case 2:
+		// If it has one of them,
+		if strings.HasSuffix(input.word, "a") && input.insistPOS != "n." && !strings.HasPrefix(input.insistPOS, "ad") {
+			// No nouns, adpositions or adverbs
+			newString = strings.TrimSuffix(input.word, "a")
+
+			newCandidate := candidateDupe(input)
+			newCandidate.word = newString
+			newCandidate.insistPOS = "adj."
+			newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "a")
+			deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, true)
+			newCandidate.insistPOS = "v."
+			deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, true)
+		}
+		for _, oldSuffix := range lastSuffixes {
+			// If it has one of them,
+			if strings.HasSuffix(input.word, oldSuffix) {
+				newString = strings.TrimSuffix(input.word, oldSuffix)
+
+				newCandidate := candidateDupe(input)
+				newCandidate.word = newString
+				newCandidate.insistPOS = "any"
+				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
+				deconjugateHelper(newCandidate, newPrefixCheck, 3, unlenite, true)
+			}
+		}
+
+		fallthrough
+	case 3: // -o suffix "some"
+		if input.insistPOS == "any" || input.insistPOS == "n." {
+			if strings.HasSuffix(input.word, "o") {
+				newString = strings.TrimSuffix(input.word, "o")
+
+				newCandidate := candidateDupe(input)
+				newCandidate.word = newString
+				newCandidate.insistPOS = "n."
+				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "o")
+				deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, false)
+
+				// Make sure fya'o-o is recognized
+				if vowel, ok := vowelSuffixes["o"]; ok {
+					// Make sure fya'o-o is recognized
+					if strings.HasSuffix(newString, vowel+"-") {
+						newString = strings.TrimSuffix(newString, "-")
+						newCandidate.word = newString
+						deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, false)
+					}
+				}
+			}
+		}
+		fallthrough
+	case 4:
+		// If it has one of them,
+		if input.insistPOS == "any" || input.insistPOS == "n." {
+			// verb suffixes change things from verbs to nouns, that's why we check for noun status
+			for _, oldSuffix := range verbSuffixes {
+				// If it has one of them,
+				if strings.HasSuffix(input.word, oldSuffix) {
+					newString = strings.TrimSuffix(input.word, oldSuffix)
+					newCandidate := candidateDupe(input)
+					newCandidate.word = newString
+					newCandidate.insistPOS = "v."
+
+					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
+					deconjugateHelper(newCandidate, 10, 10, unlenite, false) // Don't allow any other prefixes
+					// They may turn the insistPOS back into a noun
+
+					if oldSuffix == "yu" && strings.HasSuffix(newString, "si") {
+						newCandidate.word = strings.TrimSuffix(newString, "si") + " si"
+						deconjugateHelper(newCandidate, 10, 10, unlenite, false) // don't allow any other prefixes or suffixes
+					}
+				}
+			}
+		}
+		fallthrough
+	case 5:
+		if input.insistPOS == "any" || input.insistPOS == "n." {
+			for _, oldSuffix := range stemSuffixes {
+				// If it has one of them,
+				if strings.HasSuffix(input.word, oldSuffix) {
+					newString = strings.TrimSuffix(input.word, oldSuffix)
+
+					//candidates = append(candidates, newString)
+					newCandidate := candidateDupe(input)
+					newCandidate.word = newString
+					newCandidate.insistPOS = "n."
+					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
+					deconjugateHelper(newCandidate, newPrefixCheck, 6, unlenite, false)
+				}
+			}
+		}
+	}
+
+	// Short lenition check
+	if unlenite != -1 {
+		for _, oldPrefix := range unlenitionLetters {
+			// If it has a letter that could have changed for lenition,
+			if strings.HasPrefix(input.word, oldPrefix) {
+				// put all possibilities in the candidates
+				for _, newPrefix := range unlenition[oldPrefix] {
+					newCandidate := candidateDupe(input)
+					newString = newPrefix + strings.TrimPrefix(input.word, oldPrefix)
+					newCandidate.word = newString
+					if oldPrefix != newPrefix {
+						newCandidate.lenition = []string{newPrefix + "→" + oldPrefix}
+					}
+					deconjugateHelper(newCandidate, prefixCheck, suffixCheck, -1, false)
+				}
+				break // We don't want the "ts" to become "txs"
+			}
+		}
+	}
+
+	if checkInfixes {
+		// Maybe someone else came in with stripped infixes
+		if len(input.word) > 2 && input.word[len(input.word)-3] != ' ' && strings.HasSuffix(input.word, "si") && input.word != "susi" && input.word != "satsi" {
+			newCandidate := candidateDupe(input)
+			newCandidate.word = strings.TrimSuffix(input.word, "si") + " si"
+			newCandidate.insistPOS = "v."
+			deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true)
+		} else { // If there is a "si", we don't need to check for infixes
+			// Check for infixes
+			runes := []rune(input.word)
+			for i, c := range runes {
+				// Infixes can only begin with vowels
+				if has("aäeiìou", string(c)) {
+					shortString := string(runes[i:])
+					for _, infix := range infixes[c] {
+						if strings.HasPrefix(shortString, infix) {
+							newCandidate := candidateDupe(input)
+							newCandidate.word = string(runes[:i]) + strings.TrimPrefix(shortString, infix)
+							newCandidate.infixes = isDuplicateFix(newCandidate.infixes, infix)
+							newCandidate.insistPOS = "v."
+							deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true)
+
+							if infix == "ol" {
 								newCandidate := candidateDupe(input)
-								newCandidate.word = string(runes[:i]) + strings.TrimPrefix(shortString, infix)
+								newCandidate.word = string(runes[:i]) + "ll" + strings.TrimPrefix(shortString, infix)
 								newCandidate.infixes = isDuplicateFix(newCandidate.infixes, infix)
 								newCandidate.insistPOS = "v."
 								deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true)
-
-								if infix == "ol" {
-									newCandidate := candidateDupe(input)
-									newCandidate.word = string(runes[:i]) + "ll" + strings.TrimPrefix(shortString, infix)
-									newCandidate.infixes = isDuplicateFix(newCandidate.infixes, infix)
-									newCandidate.insistPOS = "v."
-									deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true)
-								} else if infix == "er" {
-									newCandidate := candidateDupe(input)
-									newCandidate.word = string(runes[:i]) + "rr" + strings.TrimPrefix(shortString, infix)
-									newCandidate.infixes = isDuplicateFix(newCandidate.infixes, infix)
-									newCandidate.insistPOS = "v."
-									deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true)
-								}
+							} else if infix == "er" {
+								newCandidate := candidateDupe(input)
+								newCandidate.word = string(runes[:i]) + "rr" + strings.TrimPrefix(shortString, infix)
+								newCandidate.infixes = isDuplicateFix(newCandidate.infixes, infix)
+								newCandidate.insistPOS = "v."
+								deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true)
 							}
 						}
 					}
 				}
 			}
 		}
-		return candidates
 	}
-	return nil
+	return candidates
 }
 
 func deconjugate(input string) []ConjugationCandidate {

--- a/cache.go
+++ b/cache.go
@@ -124,9 +124,6 @@ func AppendAndAlphabetize(words []Word, word Word) []Word {
 		return newWords
 	case 2:
 		var newWords = []Word{}
-		if word.ID == words[0].ID {
-			return words
-		}
 		if AlphabetizeHelper(word.Syllables, words[0].Syllables) {
 			newWords = []Word{word, words[0], words[1]}
 		} else if AlphabetizeHelper(words[1].Syllables, word.Syllables) {

--- a/cache.go
+++ b/cache.go
@@ -110,6 +110,15 @@ func AlphabetizeHelper(a string, b string) bool {
 }
 
 func AppendAndAlphabetize(words []Word, word Word) []Word {
+	// Ensure it's not a duplicate
+	for _, a := range words {
+		if word.ID == a.ID {
+			if len(word.Affixes.Prefix) == len(a.Affixes.Prefix) && len(word.Affixes.Suffix) == len(a.Affixes.Suffix) &&
+				len(word.Affixes.Lenition) == len(a.Affixes.Lenition) && len(word.Affixes.Infix) == len(a.Affixes.Infix) {
+				return words
+			}
+		}
+	}
 	// new array
 	switch len(words) {
 	case 0:

--- a/cache.go
+++ b/cache.go
@@ -116,9 +116,6 @@ func AppendAndAlphabetize(words []Word, word Word) []Word {
 		return []Word{word}
 	case 1:
 		var newWords = []Word{}
-		if word.ID == words[0].ID {
-			return words
-		}
 		if AlphabetizeHelper(words[0].Syllables, word.Syllables) {
 			newWords = []Word{words[0], word}
 		} else {

--- a/fwew.go
+++ b/fwew.go
@@ -259,7 +259,6 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 				if foundAlready {
 					break
 				}
-
 				keepAffixes := *new(affix)
 
 				extraWord := 0
@@ -450,9 +449,7 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 					}
 				}
 			}
-
 		}
-
 	}
 
 	// If we found nothing, at least return the query

--- a/fwew.go
+++ b/fwew.go
@@ -321,6 +321,41 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 							results[0][0].Navi += " " + allWords[i+j+2]
 							keepAffixes = itsAffixes.Affixes
 							j += 1
+							continue
+						}
+					}
+
+					// Verbs don't just come after ke or rä'ä
+					validVerb, itsAffixes := IsVerb(allWords[i+j+1], pairWord)
+					if validVerb {
+						found = true
+						foundAlready = true
+						results[0][0].Navi += " " + allWords[i+j+1]
+						keepAffixes = itsAffixes.Affixes
+						continue
+					}
+
+					// Find all words the second word can represent
+					secondWords := []Word{}
+
+					// First by itself
+					if pairWord == allWords[i+j+1] {
+						found = true
+						results[0][0].Navi += " " + allWords[i+j+1]
+						continue
+					}
+
+					// And then by its possible conjugations
+					for _, b := range TestDeconjugations(allWords[i+j+1]) {
+						secondWords = AppendAndAlphabetize(secondWords, b)
+					}
+
+					// Do any of the conjugations work?
+					for _, b := range secondWords {
+						if b.Navi == pairWord {
+							results[0][0].Navi += " " + b.Navi
+							found = true
+							keepAffixes = addAffixes(keepAffixes, b.Affixes)
 						}
 					}
 
@@ -386,6 +421,8 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 						break
 					}
 
+					newSearch := a.Navi
+
 					keepAffixes := *new(affix)
 					keepAffixes = addAffixes(keepAffixes, a.Affixes)
 
@@ -413,6 +450,32 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 									results[0][0].Navi += " " + allWords[i+j+2]
 									keepAffixes = itsAffixes.Affixes
 									j += 1
+
+									continue
+								}
+							}
+
+							// Find all words the second word can represent
+							secondWords := []Word{}
+
+							// First by itself
+							if pairWord == allWords[i+j+1] {
+								found = true
+								results[0][0].Navi += " " + allWords[i+j+1]
+								continue
+							}
+
+							// And then by its possible conjugations
+							for _, b := range TestDeconjugations(allWords[i+j+1]) {
+								secondWords = AppendAndAlphabetize(secondWords, b)
+							}
+
+							// Do any of the conjugations work?
+							for _, b := range secondWords {
+								if b.Navi == pairWord {
+									results[0][0].Navi += " " + b.Navi
+									found = true
+									keepAffixes = addAffixes(keepAffixes, b.Affixes)
 								}
 							}
 
@@ -423,7 +486,7 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 						}
 					}
 					if found {
-						fullWord := searchNaviWord
+						fullWord := newSearch
 						for _, pairWord := range pairWordSet {
 							fullWord += " " + pairWord
 						}

--- a/fwew.go
+++ b/fwew.go
@@ -329,11 +329,13 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 		if len(results) > 0 && len(results[0]) > 0 {
 			if !(strings.ToLower(results[len(results)-1][0].Navi) != searchNaviWord && strings.HasPrefix(strings.ToLower(results[len(results)-1][0].Navi), searchNaviWord)) {
 				// Find all possible unconjugated versions of the word
-				results[len(results)-1] = append(results[len(results)-1], TestDeconjugations(searchNaviWord)...)
+				newResults := TestDeconjugations(searchNaviWord)
+				results[len(results)-1] = append(results[len(results)-1], newResults...)
 			}
 		} else {
 			// Find all possible unconjugated versions of the word
-			results[len(results)-1] = append(results[len(results)-1], TestDeconjugations(searchNaviWord)...)
+			newResults := TestDeconjugations(searchNaviWord)
+			results[len(results)-1] = append(results[len(results)-1], newResults...)
 		}
 
 		// Check if the word could have more than one word
@@ -377,7 +379,8 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 							}
 
 							// And then by its possible conjugations
-							for _, b := range TestDeconjugations(allWords[i+j+1]) {
+							newResults := TestDeconjugations(searchNaviWord)
+							for _, b := range newResults {
 								secondWords = AppendAndAlphabetize(secondWords, b)
 							}
 

--- a/name_gen.go
+++ b/name_gen.go
@@ -25,6 +25,9 @@ func (s Tuples) Swap(i, j int) {
 
 func (s Tuples) Less(i, j int) bool {
 	// bigger values first here
+	if s[i].value == s[j].value {
+		return AlphabetizeHelper(s[i].letter, s[j].letter)
+	}
 	return s[i].value > s[j].value
 }
 

--- a/name_gen_core.go
+++ b/name_gen_core.go
@@ -9,6 +9,7 @@ package fwew_lib
  */
 
 import (
+	"fmt"
 	"math/rand"
 	"strings"
 	"unicode"
@@ -766,7 +767,11 @@ func PhonemeDistros() {
 					//vowel
 					nucleus_map[romanization[nth_rune(syllable, 0)]] = nucleus_map[romanization[nth_rune(syllable, 0)]] + 1
 					//roman_syllable += romanization[nth_rune(syllable, 0)]
-					syllable = string([]rune(syllable)[1:])
+					if len(syllable) == 0 {
+						fmt.Println("Invalid word: " + words[i].ID + " - " + words[i].Navi + " - " + words[i].IPA)
+					} else {
+						syllable = string([]rune(syllable)[1:])
+					}
 				}
 
 				/*

--- a/name_gen_core.go
+++ b/name_gen_core.go
@@ -9,9 +9,7 @@ package fwew_lib
  */
 
 import (
-	"fmt"
 	"math/rand"
-	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -814,7 +812,7 @@ func PhonemeDistros() {
 	}
 
 	// Show the phoneme map sorted
-	syllable_tuples := []PhonemeTuple{}
+	/*syllable_tuples := []PhonemeTuple{}
 	for key, val := range syllable_map {
 		syllable_tuples = append(syllable_tuples, PhonemeTuple{val, key})
 	}
@@ -822,7 +820,7 @@ func PhonemeDistros() {
 
 	for _, a := range syllable_tuples {
 		fmt.Println(a)
-	}
+	}*/
 
 	max_non_cluster = 0
 	max_onset = 0

--- a/name_gen_core.go
+++ b/name_gen_core.go
@@ -588,7 +588,7 @@ func PhonemeDistros() {
 		coda_map[coda_letters[i]] = 0
 	}
 
-	syllable_map := map[string]int{}
+	//syllable_map := map[string]int{}
 
 	// Look through all the words
 	for i := 0; i < len(words); i++ {
@@ -802,11 +802,11 @@ func PhonemeDistros() {
 				roman_syllable += coda
 
 				// Finally see if there is a good syllable frequency here
-				if _, ok := syllable_map[roman_syllable]; !ok {
+				/*if _, ok := syllable_map[roman_syllable]; !ok {
 					syllable_map[roman_syllable] = 1
 				} else {
 					syllable_map[roman_syllable] = syllable_map[roman_syllable] + 1
-				}
+				}*/
 			}
 		}
 	}

--- a/name_gen_core.go
+++ b/name_gen_core.go
@@ -638,7 +638,7 @@ func PhonemeDistros() {
 
 				onset_if_cluster := [2]string{"", ""}
 
-				roman_syllable := ""
+				//roman_syllable := ""
 
 				// ts
 				if len(syllable) >= 4 && syllable[0:4] == "t͡s" {
@@ -649,25 +649,25 @@ func PhonemeDistros() {
 							// ts + ejective onset
 							cluster_map["ts"][romanization[syllable[4:6]]] = cluster_map["ts"][romanization[syllable[4:6]]] + 1
 							onset_if_cluster[1] = romanization[syllable[4:6]]
-							roman_syllable += "ts" + romanization[syllable[4:6]]
+							//roman_syllable += "ts" + romanization[syllable[4:6]]
 							syllable = syllable[6:]
 						} else {
 							// ts + unvoiced plosive
 							cluster_map["ts"][romanization[string(syllable[4])]] = cluster_map["ts"][romanization[string(syllable[4])]] + 1
 							onset_if_cluster[1] = romanization[string(syllable[4])]
-							roman_syllable += "ts" + romanization[string(syllable[4])]
+							//roman_syllable += "ts" + romanization[string(syllable[4])]
 							syllable = syllable[5:]
 						}
 					} else if has("lɾmnŋwj", nth_rune(syllable, 3)) {
 						// ts + other consonent
 						cluster_map["ts"][romanization[nth_rune(syllable, 3)]] = cluster_map["ts"][romanization[nth_rune(syllable, 3)]] + 1
 						onset_if_cluster[1] = romanization[nth_rune(syllable, 3)]
-						roman_syllable += "ts" + romanization[nth_rune(syllable, 3)]
+						//roman_syllable += "ts" + romanization[nth_rune(syllable, 3)]
 						syllable = syllable[4+len(nth_rune(syllable, 3)):]
 					} else {
 						// ts without a cluster
 						onset_map["ts"] = onset_map["ts"] + 1
-						roman_syllable += "ts"
+						//roman_syllable += "ts"
 						syllable = syllable[4:]
 					}
 				} else if has("fs", nth_rune(syllable, 0)) {
@@ -678,52 +678,52 @@ func PhonemeDistros() {
 							// f/s + ejective onset
 							cluster_map[string(syllable[0])][romanization[syllable[1:3]]] = cluster_map[string(syllable[0])][romanization[syllable[1:3]]] + 1
 							onset_if_cluster[1] = romanization[syllable[1:3]]
-							roman_syllable += string(syllable[0]) + romanization[syllable[1:3]]
+							//roman_syllable += string(syllable[0]) + romanization[syllable[1:3]]
 							syllable = syllable[3:]
 						} else {
 							// f/s + unvoiced plosive
 							cluster_map[string(syllable[0])][romanization[string(syllable[1])]] = cluster_map[string(syllable[0])][romanization[string(syllable[1])]] + 1
 							onset_if_cluster[1] = romanization[string(syllable[1])]
-							roman_syllable += string(syllable[0]) + romanization[string(syllable[1])]
+							//roman_syllable += string(syllable[0]) + romanization[string(syllable[1])]
 							syllable = syllable[2:]
 						}
 					} else if has("lɾmnŋwj", nth_rune(syllable, 1)) {
 						// f/s + other consonent
 						cluster_map[string(syllable[0])][romanization[nth_rune(syllable, 1)]] = cluster_map[string(syllable[0])][romanization[nth_rune(syllable, 1)]] + 1
 						onset_if_cluster[1] = romanization[nth_rune(syllable, 1)]
-						roman_syllable += string(syllable[0]) + romanization[nth_rune(syllable, 1)]
+						//roman_syllable += string(syllable[0]) + romanization[nth_rune(syllable, 1)]
 						syllable = syllable[1+len(nth_rune(syllable, 1)):]
 					} else {
 						// f/s without a cluster
 						onset_map[string(syllable[0])] = onset_map[string(syllable[0])] + 1
-						roman_syllable += string(syllable[0])
+						//roman_syllable += string(syllable[0])
 						syllable = syllable[1:]
 					}
 				} else if has("ptk", nth_rune(syllable, 0)) {
 					if nth_rune(syllable, 1) == "'" {
 						// ejective
 						onset_map[romanization[syllable[0:2]]] = onset_map[romanization[syllable[0:2]]] + 1
-						roman_syllable += romanization[syllable[0:2]]
+						//roman_syllable += romanization[syllable[0:2]]
 						syllable = syllable[2:]
 					} else {
 						// unvoiced plosive
 						onset_map[romanization[string(syllable[0])]] = onset_map[romanization[string(syllable[0])]] + 1
-						roman_syllable += romanization[string(syllable[0])]
+						//roman_syllable += romanization[string(syllable[0])]
 						syllable = syllable[1:]
 					}
 				} else if has("ʔlɾhmnŋvwjzbdg", nth_rune(syllable, 0)) {
 					// other normal onset
 					onset_map[romanization[nth_rune(syllable, 0)]] = onset_map[romanization[nth_rune(syllable, 0)]] + 1
-					roman_syllable += romanization[nth_rune(syllable, 0)]
+					//roman_syllable += romanization[nth_rune(syllable, 0)]
 					syllable = syllable[len(nth_rune(syllable, 0)):]
 				} else if has("ʃʒ", nth_rune(syllable, 0)) {
 					// one sound representd as a cluster
 					if nth_rune(syllable, 0) == "ʃ" {
 						cluster_map["s"]["y"] = cluster_map["s"]["y"] + 1
-						roman_syllable += "sy"
+						//roman_syllable += "sy"
 					} else if nth_rune(syllable, 0) == "ʒ" {
 						cluster_map["ts"]["y"] = cluster_map["ts"]["y"] + 1
-						roman_syllable += "tsy"
+						//roman_syllable += "tsy"
 					}
 					syllable = syllable[len(nth_rune(syllable, 0)):]
 				} else {
@@ -756,16 +756,16 @@ func PhonemeDistros() {
 				if len(syllable) > 1 && has("jw", nth_rune(syllable, 1)) {
 					//diphthong
 					nucleus_map[romanization[syllable[0:len(nth_rune(syllable, 0))+1]]] = nucleus_map[romanization[syllable[0:len(nth_rune(syllable, 0))+1]]] + 1
-					roman_syllable += romanization[syllable[0:len(nth_rune(syllable, 0))+1]]
+					//roman_syllable += romanization[syllable[0:len(nth_rune(syllable, 0))+1]]
 					syllable = string([]rune(syllable)[2:])
 				} else if len(syllable) > 1 && has("lr", nth_rune(syllable, 0)) {
 					nucleus_map[romanization[syllable[0:3]]] = nucleus_map[romanization[syllable[0:3]]] + 1
-					roman_syllable += romanization[syllable[0:3]]
+					//roman_syllable += romanization[syllable[0:3]]
 					continue
 				} else {
 					//vowel
 					nucleus_map[romanization[nth_rune(syllable, 0)]] = nucleus_map[romanization[nth_rune(syllable, 0)]] + 1
-					roman_syllable += romanization[nth_rune(syllable, 0)]
+					//roman_syllable += romanization[nth_rune(syllable, 0)]
 					syllable = string([]rune(syllable)[1:])
 				}
 
@@ -799,10 +799,10 @@ func PhonemeDistros() {
 						}
 					}
 				}
-				roman_syllable += coda
+				/*roman_syllable += coda
 
 				// Finally see if there is a good syllable frequency here
-				/*if _, ok := syllable_map[roman_syllable]; !ok {
+				if _, ok := syllable_map[roman_syllable]; !ok {
 					syllable_map[roman_syllable] = 1
 				} else {
 					syllable_map[roman_syllable] = syllable_map[roman_syllable] + 1


### PR DESCRIPTION
Fixed glitches like
- _tìng lawr lawr_ returning one word and not two
- _-uyu_ verbs showing only one of two possible interpretations
- enabling _-tswo_ versions of _si-_verbs
- _toruk ke yom_ duplicating words
- _kaltxì ke_ returning nothing
- recognizes case endings after _-pe_
- shows infixes in dictionary entries like _win s[äp]i_ and _eltut h[eyk]ahaw_ when searching them by their Na'vi words