### PR TITLE
Added multilanguage support for some commands

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -515,7 +515,7 @@ func CacheDictHashOrig(mysql bool) error {
 
 		// See whether or not it violates normal phonotactic rules like Jakesully or Oìsss
 		valid := true
-		for _, a := range strings.Split(IsValidNavi(standardizedWord), "\n") {
+		for _, a := range strings.Split(IsValidNavi(standardizedWord, "en"), "\n") {
 			// Check every word.  If one of them isn't good, write down the word
 			if len(a) > 0 && (!strings.Contains(a, "Valid:") || strings.Contains(a, "reef")) {
 				valid = false
@@ -920,6 +920,12 @@ func GetFullDict() (allWords []Word, err error) {
 	return
 }
 
+// Just a number
+func GetDictSizeSimple() (count int) {
+	return len(dictionary)
+}
+
+// Return a complete sentence
 func GetDictSize(lang string) (count string, err error) {
 	// Count words
 	amount := 0

--- a/cache.go
+++ b/cache.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -918,7 +919,9 @@ func GetFullDict() (allWords []Word, err error) {
 	return
 }
 
-func GetDictSize() (amount int, err error) {
+func GetDictSize(lang string) (count string, err error) {
+	// Count words
+	amount := 0
 	if dictionaryCached {
 		amount = len(dictionary)
 	} else {
@@ -927,6 +930,40 @@ func GetDictSize() (amount int, err error) {
 			return nil
 		})
 	}
+
+	// Put the word count into a complete sentence
+	count = strconv.Itoa(amount)
+
+	if lang == "en" { // English
+		count = "There are " + count + " entries in the dictionary."
+	} else if lang == "de" { // German (Deutsch)
+		count = count + "🇩🇪"
+	} else if lang == "es" { // Spanish (Español)
+		count = count + "🇪🇦"
+	} else if lang == "et" { // Estonian (Eesti)
+		count = count + "🇪🇪"
+	} else if lang == "fr" { // French (Français)
+		count = count + "🇫🇷"
+	} else if lang == "hu" { // Hungarian (Magyar)
+		count = count + "🇭🇺"
+	} else if lang == "ko" { // Korean (한국어)
+		count = count + "🇰🇷"
+	} else if lang == "nl" { // Dutch (Nederlands)
+		count = count + "🇳🇱"
+	} else if lang == "pl" { // Polish (Polski)
+		count = count + "🇵🇱"
+	} else if lang == "pt" { // Portuguese (Português)
+		count = count + "🇵🇹"
+	} else if lang == "ru" { // Russian (Русский)
+		count = count + "🇵🇹"
+	} else if lang == "sv" { // Swedish (Svenska)
+		count = count + "🇸🇪"
+	} else if lang == "tr" { // Turkish (Türkçe)
+		count = count + "🇹🇷"
+	} else if lang == "uk" { // Ukrainian (Українська)
+		count = count + "🇺🇦"
+	}
+
 	return
 }
 

--- a/cache.go
+++ b/cache.go
@@ -961,7 +961,7 @@ func GetDictSize(lang string) (count string, err error) {
 		count = count + " 🇸🇪"
 	} else if lang == "tr" { // Turkish (Türkçe)
 		count = count + " 🇹🇷"
-	} else if lang == "uk" {
+	} else if lang == "uk" { // Ukrainian (Українська)
 		count = count + " 🇺🇦"
 	}
 

--- a/cache.go
+++ b/cache.go
@@ -937,31 +937,31 @@ func GetDictSize(lang string) (count string, err error) {
 	if lang == "en" { // English
 		count = "There are " + count + " entries in the dictionary."
 	} else if lang == "de" { // German (Deutsch)
-		count = count + "🇩🇪"
+		count = count + " 🇩🇪"
 	} else if lang == "es" { // Spanish (Español)
-		count = count + "🇪🇦"
+		count = count + " 🇪🇦"
 	} else if lang == "et" { // Estonian (Eesti)
-		count = count + "🇪🇪"
+		count = count + " 🇪🇪"
 	} else if lang == "fr" { // French (Français)
-		count = count + "🇫🇷"
+		count = count + " 🇫🇷"
 	} else if lang == "hu" { // Hungarian (Magyar)
-		count = count + "🇭🇺"
+		count = count + " 🇭🇺"
 	} else if lang == "ko" { // Korean (한국어)
-		count = count + "🇰🇷"
+		count = count + " 🇰🇷"
 	} else if lang == "nl" { // Dutch (Nederlands)
-		count = count + "🇳🇱"
+		count = count + " 🇳🇱"
 	} else if lang == "pl" { // Polish (Polski)
-		count = count + "🇵🇱"
+		count = count + " 🇵🇱"
 	} else if lang == "pt" { // Portuguese (Português)
-		count = count + "🇵🇹"
+		count = count + " 🇵🇹"
 	} else if lang == "ru" { // Russian (Русский)
-		count = count + "🇵🇹"
+		count = count + " 🇵🇹"
 	} else if lang == "sv" { // Swedish (Svenska)
-		count = count + "🇸🇪"
+		count = count + " 🇸🇪"
 	} else if lang == "tr" { // Turkish (Türkçe)
-		count = count + "🇹🇷"
+		count = count + " 🇹🇷"
 	} else if lang == "uk" { // Ukrainian (Українська)
-		count = count + "🇺🇦"
+		count = count + " 🇺🇦"
 	}
 
 	return

--- a/cache.go
+++ b/cache.go
@@ -260,6 +260,7 @@ func EnglishIfNull(word Word) Word {
 func RomanizeSecondIPA(IPA string) string {
 	// now Romanize the IPA
 	IPA = strings.ReplaceAll(IPA, "ʊ", "u")
+	IPA = strings.ReplaceAll(IPA, "õ", "o") // vonvä' as võvä' only
 	word := strings.Split(IPA, " ")
 
 	breakdown := ""

--- a/cache.go
+++ b/cache.go
@@ -955,12 +955,12 @@ func GetDictSize(lang string) (count string, err error) {
 	} else if lang == "pt" { // Portuguese (Português)
 		count = count + " 🇵🇹"
 	} else if lang == "ru" { // Russian (Русский)
-		count = count + " 🇵🇹"
+		count = count + " 🇷🇺"
 	} else if lang == "sv" { // Swedish (Svenska)
 		count = count + " 🇸🇪"
 	} else if lang == "tr" { // Turkish (Türkçe)
 		count = count + " 🇹🇷"
-	} else if lang == "uk" { // Ukrainian (Українська)
+	} else if lang == "uk" {
 		count = count + " 🇺🇦"
 	}
 

--- a/name_gen.go
+++ b/name_gen.go
@@ -364,21 +364,22 @@ func NameAlu(name_count int, dialect int, syllable_count int, noun_mode int, adj
 }
 
 func GetPhonemeDistrosMap(lang string) (allDistros [][][]string) {
+	// Non-English ones were pulled out of Google translate
 	header_row := map[string][]string{
-		"en": {"Onset", "Nucleus", "Coda"},    // English
-		"de": {"Onset 🇩🇪", "Nucleus", "Coda"}, // German (Deutsch)
-		"es": {"Onset 🇪🇦", "Nucleus", "Coda"}, // Spanish (Español)
-		"et": {"Onset 🇪🇪", "Nucleus", "Coda"}, // Estonian (Eesti)
-		"fr": {"Onset 🇫🇷", "Nucleus", "Coda"}, // French (Français)
-		"hu": {"Onset 🇭🇺", "Nucleus", "Coda"}, // Hungarian (Magyar)
-		"ko": {"Onset 🇰🇷", "Nucleus", "Coda"}, // Korean (한국어)
-		"nl": {"Onset 🇳🇱", "Nucleus", "Coda"}, // Dutch (Nederlands)
-		"pl": {"Onset 🇵🇱", "Nucleus", "Coda"}, // Polish (Polski)
-		"pt": {"Onset 🇵🇹", "Nucleus", "Coda"}, // Portuguese (Português)
-		"ru": {"Onset 🇷🇺", "Nucleus", "Coda"}, // Russian (Русский)
-		"sv": {"Onset 🇸🇪", "Nucleus", "Coda"}, // Swedish (Svenska)
-		"tr": {"Onset 🇹🇷", "Nucleus", "Coda"}, // Turkish (Türkçe)
-		"uk": {"Onset 🇺🇦", "Nucleus", "Coda"}, // Ukrainian (Українська)
+		"en": {"Onset", "Nucleus", "Coda"},          // English
+		"de": {"Beginn", "Kern", "Coda"},            // German (Deutsch)
+		"es": {"Inicio", "Núcleo", "Coda"},          // Spanish (Español)
+		"et": {"Algus", "tuum", "Coda"},             // Estonian (Eesti)
+		"fr": {"Début", "Noyau", "Coda"},            // French (Français)
+		"hu": {"Szótagkezdet", "Szótagmag", "Coda"}, // Hungarian (Magyar)
+		"ko": {"음절 시작", "음절핵", "코다"},                // Korean (한국어)
+		"nl": {"Begin", "Kern", "Coda"},             // Dutch (Nederlands)
+		"pl": {"Początek", "Jądro", "Kod"},          // Polish (Polski)
+		"pt": {"Início", "Núcleo", "Coda"},          // Portuguese (Português)
+		"ru": {"Начало", "Ядро", "Кода"},            // Russian (Русский)
+		"sv": {"Debut", "Nucleus", "Coda"},          // Swedish (Svenska)
+		"tr": {"Başlangıç", "çekirdek", "Kodası"},   // Turkish (Türkçe)
+		"uk": {"Початок", "Ядро", "Кода"},           // Ukrainian (Українська)
 	}
 
 	cluster_name := map[string]string{

--- a/name_gen.go
+++ b/name_gen.go
@@ -384,7 +384,7 @@ func GetPhonemeDistrosMap(lang string) (allDistros [][][]string) {
 
 	cluster_name := map[string]string{
 		"en": "Consonant Clusters",        // English
-		"de": "Konsonantgrupoj",           // German (Deutsch)
+		"de": "Konsonantengruppen",           // German (Deutsch)
 		"es": "Grupos de consonantes",     // Spanish (Español)
 		"et": "Konsonantide klastrid",     // Estonian (Eesti)
 		"fr": "Groupes de consonnes",      // French (Français)

--- a/name_gen.go
+++ b/name_gen.go
@@ -384,7 +384,7 @@ func GetPhonemeDistrosMap(lang string) (allDistros [][][]string) {
 
 	cluster_name := map[string]string{
 		"en": "Consonant Clusters",        // English
-		"de": "Konsonantengruppen",           // German (Deutsch)
+		"de": "Konsonantengruppen",        // German (Deutsch)
 		"es": "Grupos de consonantes",     // Spanish (Español)
 		"et": "Konsonantide klastrid",     // Estonian (Eesti)
 		"fr": "Groupes de consonnes",      // French (Français)

--- a/name_gen.go
+++ b/name_gen.go
@@ -364,7 +364,7 @@ func NameAlu(name_count int, dialect int, syllable_count int, noun_mode int, adj
 }
 
 func GetPhonemeDistrosMap(lang string) (allDistros [][][]string) {
-	headerRow := map[string][]string{
+	header_row := map[string][]string{
 		"en": {"Onset", "Nucleus", "Coda"},    // English
 		"de": {"Onset 🇩🇪", "Nucleus", "Coda"}, // German (Deutsch)
 		"es": {"Onset 🇪🇦", "Nucleus", "Coda"}, // Spanish (Español)
@@ -381,16 +381,37 @@ func GetPhonemeDistrosMap(lang string) (allDistros [][][]string) {
 		"uk": {"Onset 🇺🇦", "Nucleus", "Coda"}, // Ukrainian (Українська)
 	}
 
-	// Default to English
-	headerLang := []string{"Onset", "Nucleus", "Coda"}
+	cluster_name := map[string]string{
+		"en": "Consonant Clusters",        // English
+		"de": "Konsonantgrupoj",           // German (Deutsch)
+		"es": "Grupos de consonantes",     // Spanish (Español)
+		"et": "Konsonantide klastrid",     // Estonian (Eesti)
+		"fr": "Groupes de consonnes",      // French (Français)
+		"hu": "Mássalhangzócsoportok",     // Hungarian (Magyar)
+		"ko": "🇰🇷",                        // Korean (한국어)
+		"nl": "Medeklinkerclusters",       // Dutch (Nederlands)
+		"pl": "Zbiory spółgłosek",         // Polish (Polski)
+		"pt": "Aglomerados de consoantes", // Portuguese (Português)
+		"ru": "Согласные кластеры",        // Russian (Русский)
+		"sv": "Konsonantkluster",          // Swedish (Svenska)
+		"tr": "Ünsüz harfler",             // Turkish (Türkçe)
+		"uk": "Збори приголосних",         // Ukrainian (Українська)
+	}
 
-	if a, ok := headerRow[lang]; ok {
-		headerLang = a
+	// Default to English
+	header_lang := []string{"Onset", "Nucleus", "Coda"}
+	cluster_lang := "Consonant Clusters"
+
+	if a, ok := header_row[lang]; ok {
+		header_lang = a
+	}
+	if a, ok := cluster_name[lang]; ok {
+		cluster_lang = a
 	}
 
 	allDistros = [][][]string{
-		{headerLang},
-		{{"", "f", "s", "ts"}},
+		{header_lang},
+		{{cluster_lang, "f", "s", "ts"}},
 	}
 
 	// Convert them to tuples for sorting

--- a/name_gen.go
+++ b/name_gen.go
@@ -363,9 +363,33 @@ func NameAlu(name_count int, dialect int, syllable_count int, noun_mode int, adj
 	return output
 }
 
-func GetPhonemeDistrosMap() (allDistros [][][]string) {
+func GetPhonemeDistrosMap(lang string) (allDistros [][][]string) {
+	headerRow := map[string][]string{
+		"en": {"Onset", "Nucleus", "Coda"},    // English
+		"de": {"Onset 🇩🇪", "Nucleus", "Coda"}, // German (Deutsch)
+		"es": {"Onset 🇪🇦", "Nucleus", "Coda"}, // Spanish (Español)
+		"et": {"Onset 🇪🇪", "Nucleus", "Coda"}, // Estonian (Eesti)
+		"fr": {"Onset 🇫🇷", "Nucleus", "Coda"}, // French (Français)
+		"hu": {"Onset 🇭🇺", "Nucleus", "Coda"}, // Hungarian (Magyar)
+		"ko": {"Onset 🇰🇷", "Nucleus", "Coda"}, // Korean (한국어)
+		"nl": {"Onset 🇳🇱", "Nucleus", "Coda"}, // Dutch (Nederlands)
+		"pl": {"Onset 🇵🇱", "Nucleus", "Coda"}, // Polish (Polski)
+		"pt": {"Onset 🇵🇹", "Nucleus", "Coda"}, // Portuguese (Português)
+		"ru": {"Onset 🇷🇺", "Nucleus", "Coda"}, // Russian (Русский)
+		"sv": {"Onset 🇸🇪", "Nucleus", "Coda"}, // Swedish (Svenska)
+		"tr": {"Onset 🇹🇷", "Nucleus", "Coda"}, // Turkish (Türkçe)
+		"uk": {"Onset 🇺🇦", "Nucleus", "Coda"}, // Ukrainian (Українська)
+	}
+
+	// Default to English
+	headerLang := []string{"Onset", "Nucleus", "Coda"}
+
+	if a, ok := headerRow[lang]; ok {
+		headerLang = a
+	}
+
 	allDistros = [][][]string{
-		{{"Onset", "Nucleus", "Coda"}},
+		{headerLang},
 		{{"", "f", "s", "ts"}},
 	}
 

--- a/phonotactics-translations.go
+++ b/phonotactics-translations.go
@@ -1,0 +1,170 @@
+package fwew_lib
+
+import (
+	"strconv"
+	"strings"
+)
+
+var message_non_navi_letters = map[string]string{
+	"en": "**{oldWord}** Has letters not in Na'vi: `{nonNaviLetters}`",    // English
+	"de": "**{oldWord}** 🇩🇪 Has letters not in Na'vi: `{nonNaviLetters}`", // German (Deutsch)
+	"es": "**{oldWord}** 🇪🇦 Has letters not in Na'vi: `{nonNaviLetters}`", // Spanish (Español)
+	"et": "**{oldWord}** 🇪🇪 Has letters not in Na'vi: `{nonNaviLetters}`", // Estonian (Eesti)
+	"fr": "**{oldWord}** 🇫🇷 Has letters not in Na'vi: `{nonNaviLetters}`", // French (Français)
+	"hu": "**{oldWord}** 🇭🇺 Has letters not in Na'vi: `{nonNaviLetters}`", // Hungarian (Magyar)
+	"ko": "**{oldWord}** 🇰🇷 Has letters not in Na'vi: `{nonNaviLetters}`", // Korean (한국어)
+	"nl": "**{oldWord}** 🇳🇱 Has letters not in Na'vi: `{nonNaviLetters}`", // Dutch (Nederlands)
+	"pl": "**{oldWord}** 🇵🇱 Has letters not in Na'vi: `{nonNaviLetters}`", // Polish (Polski)
+	"pt": "**{oldWord}** 🇵🇹 Has letters not in Na'vi: `{nonNaviLetters}`", // Portuguese (Português)
+	"ru": "**{oldWord}** 🇷🇺 Has letters not in Na'vi: `{nonNaviLetters}`", // Russian (Русский)
+	"sv": "**{oldWord}** 🇸🇪 Has letters not in Na'vi: `{nonNaviLetters}`", // Swedish (Svenska)
+	"tr": "**{oldWord}** 🇹🇷 Has letters not in Na'vi: `{nonNaviLetters}`", // Turkish (Türkçe)
+	"uk": "**{oldWord}** 🇺🇦 Has letters not in Na'vi: `{nonNaviLetters}`", // Ukrainian (Українська)
+}
+
+var message_no_nuclei = map[string]string{
+	"en": "**{oldWord}** Error: could not find any syllable nuclei",    // English
+	"de": "**{oldWord}** 🇩🇪 Error: could not find any syllable nuclei", // German (Deutsch)
+	"es": "**{oldWord}** 🇪🇦 Error: could not find any syllable nuclei", // Spanish (Español)
+	"et": "**{oldWord}** 🇪🇪 Error: could not find any syllable nuclei", // Estonian (Eesti)
+	"fr": "**{oldWord}** 🇫🇷 Error: could not find any syllable nuclei", // French (Français)
+	"hu": "**{oldWord}** 🇭🇺 Error: could not find any syllable nuclei", // Hungarian (Magyar)
+	"ko": "**{oldWord}** 🇰🇷 Error: could not find any syllable nuclei", // Korean (한국어)
+	"nl": "**{oldWord}** 🇳🇱 Error: could not find any syllable nuclei", // Dutch (Nederlands)
+	"pl": "**{oldWord}** 🇵🇱 Error: could not find any syllable nuclei", // Polish (Polski)
+	"pt": "**{oldWord}** 🇵🇹 Error: could not find any syllable nuclei", // Portuguese (Português)
+	"ru": "**{oldWord}** 🇷🇺 Error: could not find any syllable nuclei", // Russian (Русский)
+	"sv": "**{oldWord}** 🇸🇪 Error: could not find any syllable nuclei", // Swedish (Svenska)
+	"tr": "**{oldWord}** 🇹🇷 Error: could not find any syllable nuclei", // Turkish (Türkçe)
+	"uk": "**{oldWord}** 🇺🇦 Error: could not find any syllable nuclei", // Ukrainian (Українська)
+}
+
+var message_invalid_consonants = map[string]string{
+	"en": "**{oldWord}** Invalid consonant combination: `{badConsonants}`",    // English
+	"de": "**{oldWord}** 🇩🇪 Invalid consonant combination: `{badConsonants}`", // German (Deutsch)
+	"es": "**{oldWord}** 🇪🇦 Invalid consonant combination: `{badConsonants}`", // Spanish (Español)
+	"et": "**{oldWord}** 🇪🇪 Invalid consonant combination: `{badConsonants}`", // Estonian (Eesti)
+	"fr": "**{oldWord}** 🇫🇷 Invalid consonant combination: `{badConsonants}`", // French (Français)
+	"hu": "**{oldWord}** 🇭🇺 Invalid consonant combination: `{badConsonants}`", // Hungarian (Magyar)
+	"ko": "**{oldWord}** 🇰🇷 Invalid consonant combination: `{badConsonants}`", // Korean (한국어)
+	"nl": "**{oldWord}** 🇳🇱 Invalid consonant combination: `{badConsonants}`", // Dutch (Nederlands)
+	"pl": "**{oldWord}** 🇵🇱 Invalid consonant combination: `{badConsonants}`", // Polish (Polski)
+	"pt": "**{oldWord}** 🇵🇹 Invalid consonant combination: `{badConsonants}`", // Portuguese (Português)
+	"ru": "**{oldWord}** 🇷🇺 Invalid consonant combination: `{badConsonants}`", // Russian (Русский)
+	"sv": "**{oldWord}** 🇸🇪 Invalid consonant combination: `{badConsonants}`", // Swedish (Svenska)
+	"tr": "**{oldWord}** 🇹🇷 Invalid consonant combination: `{badConsonants}`", // Turkish (Türkçe)
+	"uk": "**{oldWord}** 🇺🇦 Invalid consonant combination: `{badConsonants}`", // Ukrainian (Українська)
+}
+
+var message_needed_vowel = map[string]string{
+	"en": "**{oldWord}** Needs a vowel, diphthong or psuedovowel here: `{breakdown}`",    // English
+	"de": "**{oldWord}** 🇩🇪 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // German (Deutsch)
+	"es": "**{oldWord}** 🇪🇦 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Spanish (Español)
+	"et": "**{oldWord}** 🇪🇪 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Estonian (Eesti)
+	"fr": "**{oldWord}** 🇫🇷 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // French (Français)
+	"hu": "**{oldWord}** 🇭🇺 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Hungarian (Magyar)
+	"ko": "**{oldWord}** 🇰🇷 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Korean (한국어)
+	"nl": "**{oldWord}** 🇳🇱 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Dutch (Nederlands)
+	"pl": "**{oldWord}** 🇵🇱 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Polish (Polski)
+	"pt": "**{oldWord}** 🇵🇹 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Portuguese (Português)
+	"ru": "**{oldWord}** 🇷🇺 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Russian (Русский)
+	"sv": "**{oldWord}** 🇸🇪 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Swedish (Svenska)
+	"tr": "**{oldWord}** 🇹🇷 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Turkish (Türkçe)
+	"uk": "**{oldWord}** 🇺🇦 Needs a vowel, diphthong or psuedovowel here: `{breakdown}`", // Ukrainian (Українська)
+}
+
+var message_psuedovowels_cant_coda = map[string]string{
+	"en": "**{oldWord}** Psuedovowels can't accept codas: `{breakdown}`",    // English
+	"de": "**{oldWord}** 🇩🇪 Psuedovowels can't accept codas: `{breakdown}`", // German (Deutsch)
+	"es": "**{oldWord}** 🇪🇦 Psuedovowels can't accept codas: `{breakdown}`", // Spanish (Español)
+	"et": "**{oldWord}** 🇪🇪 Psuedovowels can't accept codas: `{breakdown}`", // Estonian (Eesti)
+	"fr": "**{oldWord}** 🇫🇷 Psuedovowels can't accept codas: `{breakdown}`", // French (Français)
+	"hu": "**{oldWord}** 🇭🇺 Psuedovowels can't accept codas: `{breakdown}`", // Hungarian (Magyar)
+	"ko": "**{oldWord}** 🇰🇷 Psuedovowels can't accept codas: `{breakdown}`", // Korean (한국어)
+	"nl": "**{oldWord}** 🇳🇱 Psuedovowels can't accept codas: `{breakdown}`", // Dutch (Nederlands)
+	"pl": "**{oldWord}** 🇵🇱 Psuedovowels can't accept codas: `{breakdown}`", // Polish (Polski)
+	"pt": "**{oldWord}** 🇵🇹 Psuedovowels can't accept codas: `{breakdown}`", // Portuguese (Português)
+	"ru": "**{oldWord}** 🇷🇺 Psuedovowels can't accept codas: `{breakdown}`", // Russian (Русский)
+	"sv": "**{oldWord}** 🇸🇪 Psuedovowels can't accept codas: `{breakdown}`", // Swedish (Svenska)
+	"tr": "**{oldWord}** 🇹🇷 Psuedovowels can't accept codas: `{breakdown}`", // Turkish (Türkçe)
+	"uk": "**{oldWord}** 🇺🇦 Psuedovowels can't accept codas: `{breakdown}`", // Ukrainian (Українська)
+}
+
+var message_psuedovowels_must_onset = map[string]string{
+	"en": "**{oldWord}** Psuedovowels must have onsets: `{breakdown}`",    // English
+	"de": "**{oldWord}** 🇩🇪 Psuedovowels must have onsets: `{breakdown}`", // German (Deutsch)
+	"es": "**{oldWord}** 🇪🇦 Psuedovowels must have onsets: `{breakdown}`", // Spanish (Español)
+	"et": "**{oldWord}** 🇪🇪 Psuedovowels must have onsets: `{breakdown}`", // Estonian (Eesti)
+	"fr": "**{oldWord}** 🇫🇷 Psuedovowels must have onsets: `{breakdown}`", // French (Français)
+	"hu": "**{oldWord}** 🇭🇺 Psuedovowels must have onsets: `{breakdown}`", // Hungarian (Magyar)
+	"ko": "**{oldWord}** 🇰🇷 Psuedovowels must have onsets: `{breakdown}`", // Korean (한국어)
+	"nl": "**{oldWord}** 🇳🇱 Psuedovowels must have onsets: `{breakdown}`", // Dutch (Nederlands)
+	"pl": "**{oldWord}** 🇵🇱 Psuedovowels must have onsets: `{breakdown}`", // Polish (Polski)
+	"pt": "**{oldWord}** 🇵🇹 Psuedovowels must have onsets: `{breakdown}`", // Portuguese (Português)
+	"ru": "**{oldWord}** 🇷🇺 Psuedovowels must have onsets: `{breakdown}`", // Russian (Русский)
+	"sv": "**{oldWord}** 🇸🇪 Psuedovowels must have onsets: `{breakdown}`", // Swedish (Svenska)
+	"tr": "**{oldWord}** 🇹🇷 Psuedovowels must have onsets: `{breakdown}`", // Turkish (Türkçe)
+	"uk": "**{oldWord}** 🇺🇦 Psuedovowels must have onsets: `{breakdown}`", // Ukrainian (Українська)
+}
+
+var message_triple_liquid = map[string]string{
+	"en": "**{oldWord}** Triple Rs or Ls aren't allowed: `{breakdown}`",    // English
+	"de": "**{oldWord}** 🇩🇪 Triple Rs or Ls aren't allowed: `{breakdown}`", // German (Deutsch)
+	"es": "**{oldWord}** 🇪🇦 Triple Rs or Ls aren't allowed: `{breakdown}`", // Spanish (Español)
+	"et": "**{oldWord}** 🇪🇪 Triple Rs or Ls aren't allowed: `{breakdown}`", // Estonian (Eesti)
+	"fr": "**{oldWord}** 🇫🇷 Triple Rs or Ls aren't allowed: `{breakdown}`", // French (Français)
+	"hu": "**{oldWord}** 🇭🇺 Triple Rs or Ls aren't allowed: `{breakdown}`", // Hungarian (Magyar)
+	"ko": "**{oldWord}** 🇰🇷 Triple Rs or Ls aren't allowed: `{breakdown}`", // Korean (한국어)
+	"nl": "**{oldWord}** 🇳🇱 Triple Rs or Ls aren't allowed: `{breakdown}`", // Dutch (Nederlands)
+	"pl": "**{oldWord}** 🇵🇱 Triple Rs or Ls aren't allowed: `{breakdown}`", // Polish (Polski)
+	"pt": "**{oldWord}** 🇵🇹 Triple Rs or Ls aren't allowed: `{breakdown}`", // Portuguese (Português)
+	"ru": "**{oldWord}** 🇷🇺 Triple Rs or Ls aren't allowed: `{breakdown}`", // Russian (Русский)
+	"sv": "**{oldWord}** 🇸🇪 Triple Rs or Ls aren't allowed: `{breakdown}`", // Swedish (Svenska)
+	"tr": "**{oldWord}** 🇹🇷 Triple Rs or Ls aren't allowed: `{breakdown}`", // Turkish (Türkçe)
+	"uk": "**{oldWord}** 🇺🇦 Triple Rs or Ls aren't allowed: `{breakdown}`", // Ukrainian (Українська)
+}
+
+var message_reef_dialect = map[string]string{
+	"en": " (In reef dialect.  Forest dialect {breakdown})", // English
+	"de": " (In reef dialect.  Forest dialect {breakdown})", // German (Deutsch)
+	"es": " (In reef dialect.  Forest dialect {breakdown})", // Spanish (Español)
+	"et": " (In reef dialect.  Forest dialect {breakdown})", // Estonian (Eesti)
+	"fr": " (In reef dialect.  Forest dialect {breakdown})", // French (Français)
+	"hu": " (In reef dialect.  Forest dialect {breakdown})", // Hungarian (Magyar)
+	"ko": " (In reef dialect.  Forest dialect {breakdown})", // Korean (한국어)
+	"nl": " (In reef dialect.  Forest dialect {breakdown})", // Dutch (Nederlands)
+	"pl": " (In reef dialect.  Forest dialect {breakdown})", // Polish (Polski)
+	"pt": " (In reef dialect.  Forest dialect {breakdown})", // Portuguese (Português)
+	"ru": " (In reef dialect.  Forest dialect {breakdown})", // Russian (Русский)
+	"sv": " (In reef dialect.  Forest dialect {breakdown})", // Swedish (Svenska)
+	"tr": " (In reef dialect.  Forest dialect {breakdown})", // Turkish (Türkçe)
+	"uk": " (In reef dialect.  Forest dialect {breakdown})", // Ukrainian (Українська)
+}
+
+var message_valid = map[string]string{
+	"en": "**{oldWord}** Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}",    // English
+	"de": "**{oldWord}** 🇩🇪 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // German (Deutsch)
+	"es": "**{oldWord}** 🇪🇦 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Spanish (Español)
+	"et": "**{oldWord}** 🇪🇪 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Estonian (Eesti)
+	"fr": "**{oldWord}** 🇫🇷 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // French (Français)
+	"hu": "**{oldWord}** 🇭🇺 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Hungarian (Magyar)
+	"ko": "**{oldWord}** 🇰🇷 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Korean (한국어)
+	"nl": "**{oldWord}** 🇳🇱 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Dutch (Nederlands)
+	"pl": "**{oldWord}** 🇵🇱 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Polish (Polski)
+	"pt": "**{oldWord}** 🇵🇹 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Portuguese (Português)
+	"ru": "**{oldWord}** 🇷🇺 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Russian (Русский)
+	"sv": "**{oldWord}** 🇸🇪 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Swedish (Svenska)
+	"tr": "**{oldWord}** 🇹🇷 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Turkish (Türkçe)
+	"uk": "**{oldWord}** 🇺🇦 Valid: `{breakdown}` with {syllable_count} syllables {syllable_forest}", // Ukrainian (Українська)
+}
+
+func valid_message(syllable_count int, lang string) string {
+	if lang == "en" {
+		if syllable_count == 1 {
+			message := strings.ReplaceAll(message_valid[lang], "syllables", "syllable")
+			message = strings.ReplaceAll(message, "{syllable_count}", strconv.Itoa(syllable_count))
+			return message
+		}
+	}
+	return strings.ReplaceAll(message_valid[lang], "{syllable_count}", strconv.Itoa(syllable_count))
+}

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -304,7 +304,7 @@ func IsValidNaviHelper(word string) string {
 		for _, a := range []string{"a", "ä", "e", "i", "ì", "o", "u", "ù"} {
 			// First pass: a-a-a-a-a-a is seen as [a-a]-[a-a]-[a-a] and becomes a-ya-a-ya-a-ya
 			syllable_forest = strings.ReplaceAll(syllable_forest, a+"-"+a, a+"-y"+a)
-			// Second pass: a-ya-a-ya is seen as a-y[a-a]-y[a-a]-ya and becomes a-ya-ya-ya-ya-ya
+			// Second pass: a-ya-a-ya-a-ya is seen as a-y[a-a]-y[a-a]-ya and becomes a-ya-ya-ya-ya-ya
 			syllable_forest = strings.ReplaceAll(syllable_forest, a+"-"+a, a+"-y"+a)
 		}
 		syllable_forest = strings.ReplaceAll(syllable_forest, "i-ì", "i-yì")

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -302,6 +302,9 @@ func IsValidNaviHelper(word string) string {
 		syllable_forest = strings.ReplaceAll(syllable_forest, "d", "tx")
 		syllable_forest = strings.ReplaceAll(syllable_forest, "g", "kx")
 		for _, a := range []string{"a", "ä", "e", "i", "ì", "o", "u", "ù"} {
+			// First pass: a-a-a-a-a-a is seen as [a-a]-[a-a]-[a-a] and becomes a-ya-a-ya-a-ya
+			syllable_forest = strings.ReplaceAll(syllable_forest, a+"-"+a, a+"-y"+a)
+			// Second pass: a-ya-a-ya is seen as a-y[a-a]-y[a-a]-ya and becomes a-ya-ya-ya-ya-ya
 			syllable_forest = strings.ReplaceAll(syllable_forest, a+"-"+a, a+"-y"+a)
 		}
 		syllable_forest = strings.ReplaceAll(syllable_forest, "i-ì", "i-yì")

--- a/phonotactics.go
+++ b/phonotactics.go
@@ -16,8 +16,38 @@ var letters_end = []string{"", "p", "t", "k", "b", "d", "q", "'",
 
 var letters_map = map[string]string{}
 
+func MakeSyllableBreakdown(syllables []string) string {
+	syllable_breakdown_temp := ""
+	for i, a := range syllables {
+		if i != len(syllables)-1 && i != 0 {
+			syllable_breakdown_temp += "-"
+		}
+		syllable_breakdown_temp += a
+	}
+	return syllable_breakdown_temp
+}
+
+// Turns things like maw-ey into ma-wey, so the checker knows
+// mawll is valid as ma-wll and not mistaken for maw-ll (invalid)
+func NoDoubleDiphthongs(syllable_breakdown string) string {
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "2-0", "a-w0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "2-1", "a-w1")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "3-0", "a-y0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "3-1", "a-y1")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "4-0", "e-w0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "4-1", "e-w1")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "5-0", "e-y0")
+	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "5-1", "e-y1")
+	return syllable_breakdown
+}
+
 // See if a word is phonotactically valid in Na'vi
-func IsValidNaviHelper(word string) string {
+func IsValidNaviHelper(word string, lang string) string {
+	// Protect against odd language values
+	if _, ok := message_valid[lang]; !ok {
+		lang = "en" // default to English
+	}
+
 	oldWord := word
 	// Phase 0: Clean up the word
 	word = strings.ToLower(word)
@@ -67,8 +97,11 @@ func IsValidNaviHelper(word string) string {
 		}
 	}
 
+	// ERROR 1a: letters not in Na'vi
 	if len(nonNaviLetters) > 0 {
-		return "❌ **" + oldWord + "** Has letters not in Na'vi: " + nonNaviLetters
+		message := strings.ReplaceAll(message_non_navi_letters[lang], "{oldWord}", oldWord)
+		message = strings.ReplaceAll(message, "{nonNaviLetters}", nonNaviLetters)
+		return "❌ " + message
 	}
 
 	// Phase 1: don't confuse the digraph compression things
@@ -109,8 +142,11 @@ func IsValidNaviHelper(word string) string {
 	// But the user can say otherwise
 	tempWord = strings.ReplaceAll(tempWord, ">G", "G")
 
+	// ERROR 1b: letters not in Na'vi
 	if badLetters != "" {
-		return "❌ **" + oldWord + "** Invalid letters: `" + badLetters + "`"
+		message := strings.ReplaceAll(message_non_navi_letters[lang], "{oldWord}", oldWord)
+		message = strings.ReplaceAll(message, "{nonNaviLetters}", badLetters)
+		return "❌ " + message
 	}
 
 	// Phase 2: Compress digraphs and divide into syllable boundaries
@@ -138,8 +174,10 @@ func IsValidNaviHelper(word string) string {
 		}
 	}
 
+	// ERROR 2: No syllable nuclei
 	if len(word_nuclei) == 0 {
-		return "❌ **" + oldWord + "** Error: could not find any syllable nuclei"
+		message := strings.ReplaceAll(message_no_nuclei[lang], "{oldWord}", oldWord)
+		return "❌ " + message
 	}
 
 	// Phase 2.1: Go through syllable boundaries
@@ -149,8 +187,10 @@ func IsValidNaviHelper(word string) string {
 		a = strings.ReplaceAll(a, " ", "")
 		if b, ok := letters_map[a]; ok {
 			syllable_breakdown = syllable_breakdown + b
-		} else {
-			return "❌ **" + oldWord + "** Invalid consonant combination: `" + strings.ToLower(decompress(a)) + "`"
+		} else { // ERROR 3: Invalid consonant combination
+			message := strings.ReplaceAll(message_invalid_consonants[lang], "{oldWord}", oldWord)
+			message = strings.ReplaceAll(message, "{badConsonants}", strings.ToLower(decompress(a)))
+			return "❌ " + message
 		}
 		if i < len(word_nuclei) {
 			syllable_breakdown = syllable_breakdown + string(word_nuclei[i])
@@ -173,8 +213,14 @@ func IsValidNaviHelper(word string) string {
 		}
 	}
 
+	// ERROR 4a: Incomplete syllables
 	if !contains[0] {
-		return "❌ **" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
+		syllables[0] += "•"
+		syllable_breakdown_2 := MakeSyllableBreakdown(syllables)
+		syllable_breakdown_2 = NoDoubleDiphthongs(syllable_breakdown_2)
+		message := strings.ReplaceAll(message_needed_vowel[lang], "{oldWord}", oldWord)
+		message = strings.ReplaceAll(message, "{breakdown}", strings.ToLower(decompress(syllable_breakdown_2)))
+		return "❌ " + message
 	}
 
 	if !contains[1] {
@@ -187,7 +233,12 @@ func IsValidNaviHelper(word string) string {
 		}
 
 		if !can_end_a_word {
-			return "❌ **" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
+			syllables[len(syllables)-1] += "•"
+			syllable_breakdown_2 := MakeSyllableBreakdown(syllables)
+			syllable_breakdown_2 = NoDoubleDiphthongs(syllable_breakdown_2)
+			message := strings.ReplaceAll(message_needed_vowel[lang], "{oldWord}", oldWord)
+			message = strings.ReplaceAll(message, "{breakdown}", strings.ToLower(decompress(syllable_breakdown_2)))
+			return "❌ " + message
 		}
 
 		can_coda := false
@@ -200,46 +251,41 @@ func IsValidNaviHelper(word string) string {
 		}
 
 		if !can_coda {
-			return "❌ **" + oldWord + "** Incomplete syllables: `" + strings.ToLower(decompress(syllable_breakdown)) + "`"
+			syllables[len(syllables)-1] += "•"
+			syllable_breakdown_2 := MakeSyllableBreakdown(syllables)
+			syllable_breakdown_2 = NoDoubleDiphthongs(syllable_breakdown_2)
+			message := strings.ReplaceAll(message_needed_vowel[lang], "{oldWord}", oldWord)
+			message = strings.ReplaceAll(message, "{breakdown}", strings.ToLower(decompress(syllable_breakdown_2)))
+			return "❌ " + message
 		}
 
-		syllable_breakdown_temp := ""
-
-		for i, a := range syllables {
-			if i != len(syllables)-1 {
-				syllable_breakdown_temp += "-"
-			}
-			syllable_breakdown_temp += a
-		}
-
-		syllable_breakdown = strings.TrimPrefix(syllable_breakdown_temp, "-")
+		syllable_breakdown = MakeSyllableBreakdown(syllables)
 	}
 
 	// Finally, psuedovowels cannot accept codas
 	for _, a := range letters_end {
 		if a != "" && (strings.Contains(syllable_breakdown, "0"+a) || strings.Contains(syllable_breakdown, "1"+a)) {
-			return "❌ **" + oldWord + "** Psuedovowels can't accept codas: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
+			message := strings.ReplaceAll(message_psuedovowels_cant_coda[lang], "{oldWord}", oldWord)
+			message = strings.ReplaceAll(message, "{breakdown}", strings.ToLower(decompress(syllable_breakdown)))
+			return "❌ " + message
 		}
 	}
 
 	// Ensure no diphthong confuses the checker (as in "ewll" becoming "ew-ll" and not "e-wll")
-	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "2-0", "a-w0")
-	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "2-1", "a-w1")
-	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "3-0", "a-y0")
-	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "3-1", "a-y1")
-	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "4-0", "e-w0")
-	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "4-1", "e-w1")
-	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "5-0", "e-y0")
-	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "5-1", "e-y1")
+	syllable_breakdown = NoDoubleDiphthongs(syllable_breakdown)
 
 	if strings.Contains(syllable_breakdown, "-0-") || strings.Contains(syllable_breakdown, "-1-") ||
 		strings.HasPrefix(syllable_breakdown, "0") || strings.HasPrefix(syllable_breakdown, "1") ||
 		strings.HasSuffix(syllable_breakdown, "-0") || strings.HasSuffix(syllable_breakdown, "-1") {
-		return "❌ **" + oldWord + "** Psuedovowels must have onsets: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
+		message := strings.ReplaceAll(message_psuedovowels_must_onset[lang], "{oldWord}", oldWord)
+		message = strings.ReplaceAll(message, "{breakdown}", strings.ToLower(decompress(syllable_breakdown)))
+		return "❌ " + message
 	}
 
 	if strings.Contains(syllable_breakdown, "0-r") || strings.Contains(syllable_breakdown, "1-l") {
-		return "❌ **" + oldWord + "** Triple Rs or Ls aren't allowed: `" + decompress(strings.ToLower(syllable_breakdown)) + "`"
+		message := strings.ReplaceAll(message_triple_liquid[lang], "{oldWord}", oldWord)
+		message = strings.ReplaceAll(message, "{breakdown}", strings.ToLower(decompress(syllable_breakdown)))
+		return "❌ " + message
 	}
 
 	// If you reach here, the word is valid
@@ -247,35 +293,35 @@ func IsValidNaviHelper(word string) string {
 
 	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "ng", "0")
 
-	isReef := ""
+	isReef := false
 	if strings.ContainsAny(syllable_breakdown, "bdg") || strings.Contains(oldWord, "ch") || strings.Contains(oldWord, "sh") {
 		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "tsy", "ch")
 		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "sy", "sh")
-		isReef = " (in reef dialect"
+		isReef = true
 	}
 	syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "0", "ng")
 
 	// Identical adjacent vowels mean reef Na'vi
-	if len(isReef) == 0 {
+	if !isReef {
 		found := false
 		for _, a := range []string{"a", "ä", "e", "i", "ì", "o", "u", "ù"} {
 			if strings.Contains(syllable_breakdown, a+"-"+a) {
-				isReef = " (in reef dialect"
+				isReef = true
 				found = true
 				break
 			}
 		}
 		if !found {
 			if strings.Contains(syllable_breakdown, "i-ì") || strings.Contains(syllable_breakdown, "ì-i") {
-				isReef = " (in reef dialect"
+				isReef = true
 			}
 		}
 	}
 
 	// So does ù
-	if len(isReef) == 0 {
+	if !isReef {
 		if strings.Contains(syllable_breakdown, "ù") {
-			isReef = " (in reef dialect"
+			isReef = true
 		}
 	}
 
@@ -286,15 +332,9 @@ func IsValidNaviHelper(word string) string {
 		syllable_breakdown = strings.ReplaceAll(syllable_breakdown, "y-"+string(a), "-y"+string(a))
 	}
 
-	syllable_word := " syllables"
-	syllable_count := len(strings.Split(syllable_breakdown, "-"))
-	if syllable_count == 1 {
-		syllable_word = " syllable"
-	}
-
 	// If reef dialect is present, show what forest looks like
 	syllable_forest := ""
-	if len(isReef) > 0 {
+	if isReef {
 		syllable_forest = strings.ReplaceAll(syllable_breakdown, "sh", "sy")
 		syllable_forest = strings.ReplaceAll(syllable_forest, "ng", "0")
 		syllable_forest = strings.ReplaceAll(syllable_forest, "ch", "tsy")
@@ -310,13 +350,19 @@ func IsValidNaviHelper(word string) string {
 		syllable_forest = strings.ReplaceAll(syllable_forest, "i-ì", "i-yì")
 		syllable_forest = strings.ReplaceAll(syllable_forest, "ì-i", "ì-yi")
 		syllable_forest = strings.ReplaceAll(syllable_forest, "0", "ng")
-		syllable_forest = ", forest dialect `" + syllable_forest + "`)"
+		syllable_forest = strings.ReplaceAll(message_reef_dialect[lang], "{breakdown}", syllable_forest)
 	}
 
-	return "✅ **" + oldWord + "** Valid: `" + syllable_breakdown + "` with " + strconv.Itoa(syllable_count) + syllable_word + isReef + syllable_forest
+	syllable_count := len(strings.Split(syllable_breakdown, "-"))
+	message := valid_message(syllable_count, lang)
+	message = strings.ReplaceAll(message, "{oldWord}", oldWord)
+	message = strings.ReplaceAll(message, "{breakdown}", strings.ToLower(decompress(syllable_breakdown)))
+	message = strings.ReplaceAll(message, "{syllable_forest}", syllable_forest)
+
+	return "✅ " + message
 }
 
-func IsValidNavi(word string) string {
+func IsValidNavi(word string, lang string) string {
 	// Let it know of valid syllable boundaries
 	if len(letters_map) == 0 {
 		for _, a := range letters_end {
@@ -347,7 +393,7 @@ func IsValidNavi(word string) string {
 	}
 	results := ""
 	for i, a := range strings.Split(word, " ") {
-		newLine := IsValidNaviHelper(a) + "\n"
+		newLine := IsValidNaviHelper(a, lang) + "\n"
 		if len(results)+len(newLine) > 1914 {
 			results += "⛔ (stopped at " + strconv.Itoa(i+1) + ". 2000 Character limit)"
 			break


### PR DESCRIPTION
Now supports several languages for the phrases:
- "There are [x] words in the dictionary"
- "Onset", "Nucleus", "Coda"
- "Consonant clusters"
`IsValidNavi()`: Fixed missing Ys in forest dialect versions of reef dialect words with 3 or more consecutive identical vowels