### PR TITLE
Programmed thread safety into the library

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -58,7 +58,9 @@ var letterMap = map[rune]int{
 var nkx = []string{}
 var nkxSub = map[string]string{}
 
-// A mutex to ensure requests to
+// A mutex to ensure concurrent requests to the
+// dictionary and phoneme counts will not cause
+// the program to crash
 var universalLock sync.Mutex
 var phonoLock sync.Mutex
 

--- a/cache.go
+++ b/cache.go
@@ -958,6 +958,8 @@ func runOnFile(f func(word Word) error) error {
 }
 
 func GetFullDict() (allWords []Word, err error) {
+	universalLock.Lock()
+	defer universalLock.Unlock()
 	if dictionaryCached {
 		allWords = dictionary
 	} else {

--- a/cache.go
+++ b/cache.go
@@ -60,6 +60,7 @@ var nkxSub = map[string]string{}
 
 // A mutex to ensure requests to
 var universalLock sync.Mutex
+var phonoLock sync.Mutex
 
 // helper for nkx for shortest words first
 func shortestFirst(array []string, input string) []string {
@@ -958,8 +959,7 @@ func runOnFile(f func(word Word) error) error {
 }
 
 func GetFullDict() (allWords []Word, err error) {
-	universalLock.Lock()
-	defer universalLock.Unlock()
+	// No need for the lock because only List() calls it
 	if dictionaryCached {
 		allWords = dictionary
 	} else {

--- a/cache.go
+++ b/cache.go
@@ -974,6 +974,8 @@ func GetFullDict() (allWords []Word, err error) {
 
 // Just a number
 func GetDictSizeSimple() (count int) {
+	universalLock.Lock()
+	defer universalLock.Unlock()
 	return len(dictionary)
 }
 

--- a/cache.go
+++ b/cache.go
@@ -978,6 +978,7 @@ func GetDictSizeSimple() (count int) {
 // Return a complete sentence
 func GetDictSize(lang string) (count string, err error) {
 	universalLock.Lock()
+	defer universalLock.Unlock()
 	// Count words
 	amount := 0
 	if dictionaryCached {
@@ -988,7 +989,6 @@ func GetDictSize(lang string) (count string, err error) {
 			return nil
 		})
 	}
-	universalLock.Unlock()
 
 	// Put the word count into a complete sentence
 	count = strconv.Itoa(amount)
@@ -1031,6 +1031,7 @@ func GetDictSize(lang string) (count string, err error) {
 // the dict while updating
 func UpdateDict() error {
 	universalLock.Lock()
+	defer universalLock.Unlock()
 	err := DownloadDict("")
 	if err != nil {
 		log.Println(Text("downloadError"))
@@ -1062,7 +1063,6 @@ func UpdateDict() error {
 		log.Printf("Error caching dict after updating ... Cache disabled")
 		return err
 	}
-	universalLock.Unlock()
 
 	return nil
 }

--- a/cache.go
+++ b/cache.go
@@ -977,6 +977,7 @@ func GetDictSizeSimple() (count int) {
 
 // Return a complete sentence
 func GetDictSize(lang string) (count string, err error) {
+	universalLock.Lock()
 	// Count words
 	amount := 0
 	if dictionaryCached {
@@ -987,6 +988,7 @@ func GetDictSize(lang string) (count string, err error) {
 			return nil
 		})
 	}
+	universalLock.Unlock()
 
 	// Put the word count into a complete sentence
 	count = strconv.Itoa(amount)

--- a/fwew.go
+++ b/fwew.go
@@ -932,6 +932,8 @@ func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode strin
 // If args are applied, the dict will be filtered for args before random words are chosen.
 // args will be put into the `List()` algorithm.
 func Random(amount int, args []string, checkDigraphs uint8) (results []Word, err error) {
+	universalLock.Lock()
+	defer universalLock.Unlock()
 	allWords, err := List(args, checkDigraphs)
 
 	if err != nil {

--- a/fwew.go
+++ b/fwew.go
@@ -152,6 +152,7 @@ func clean(searchNaviWords string) (words string) {
 // The first word will only contain the query put into the translate command
 // One Navi-Word can have multiple meanings and words (e.g. synonyms)
 func TranslateFromNaviHash(searchNaviWords string, checkFixes bool) (results [][]Word, err error) {
+	universalLock.Lock()
 	searchNaviWords = clean(searchNaviWords)
 
 	// No Results if empty string after removing sketch chars
@@ -203,6 +204,7 @@ func TranslateFromNaviHash(searchNaviWords string, checkFixes bool) (results [][
 		i += j
 		i++
 	}
+	universalLock.Unlock()
 
 	return
 }
@@ -620,6 +622,7 @@ func SearchNatlangWord(wordmap map[string][]string, searchWord string) (results 
 }
 
 func TranslateToNaviHash(searchWord string, langCode string) (results [][]Word) {
+	universalLock.Lock()
 	searchWord = clean(searchWord)
 
 	results = [][]Word{}
@@ -638,7 +641,7 @@ func TranslateToNaviHash(searchWord string, langCode string) (results [][]Word) 
 		tempResults = append(tempResults, results[len(results)-1]...)
 		results[len(results)-1] = tempResults
 	}
-
+	universalLock.Lock()
 	return
 }
 
@@ -881,6 +884,7 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 // This will return a 2D array of Words, that fit the input text
 // One Word can have multiple meanings and words (e.g. synonyms)
 func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode string) (results [][]Word, err error) {
+	universalLock.Lock()
 	searchNaviWords = clean(searchNaviWords)
 
 	// No Results if empty string after removing sketch chars
@@ -920,7 +924,7 @@ func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode strin
 
 		i++
 	}
-
+	universalLock.Unlock()
 	return
 }
 
@@ -1325,6 +1329,7 @@ func ReefMe(ipa string, inter bool) []string {
 }
 
 func StartEverything() string {
+	universalLock.Lock()
 	start := time.Now()
 	var errors = []error{
 		AssureDict(),
@@ -1339,6 +1344,6 @@ func StartEverything() string {
 	}
 	PhonemeDistros()
 	elapsed := strconv.FormatFloat(time.Since(start).Seconds(), 'f', -1, 64)
-
+	universalLock.Unlock()
 	return fmt.Sprintln("Everything is cached.  Took " + elapsed + " seconds")
 }

--- a/fwew.go
+++ b/fwew.go
@@ -641,7 +641,7 @@ func TranslateToNaviHash(searchWord string, langCode string) (results [][]Word) 
 		tempResults = append(tempResults, results[len(results)-1]...)
 		results[len(results)-1] = tempResults
 	}
-	universalLock.Lock()
+	universalLock.Unlock()
 	return
 }
 

--- a/fwew.go
+++ b/fwew.go
@@ -902,6 +902,7 @@ func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode strin
 		// Search for Na'vi words
 		j, newWords, error2 := TranslateFromNaviHashHelper(i, allWords, checkFixes)
 		if error2 == nil {
+			results[len(results)-1][0].Navi = newWords[0][0].Navi
 			for _, newWord := range newWords {
 				// Set up receptacle for words
 				results = append(results, []Word{})

--- a/fwew.go
+++ b/fwew.go
@@ -932,8 +932,6 @@ func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode strin
 // If args are applied, the dict will be filtered for args before random words are chosen.
 // args will be put into the `List()` algorithm.
 func Random(amount int, args []string, checkDigraphs uint8) (results []Word, err error) {
-	universalLock.Lock()
-	defer universalLock.Unlock()
 	allWords, err := List(args, checkDigraphs)
 
 	if err != nil {

--- a/fwew.go
+++ b/fwew.go
@@ -1332,7 +1332,6 @@ func ReefMe(ipa string, inter bool) []string {
 
 func StartEverything() string {
 	universalLock.Lock()
-	defer universalLock.Unlock()
 	start := time.Now()
 	var errors = []error{
 		AssureDict(),
@@ -1345,6 +1344,7 @@ func StartEverything() string {
 			log.Println(err)
 		}
 	}
+	universalLock.Unlock()
 	PhonemeDistros()
 	elapsed := strconv.FormatFloat(time.Since(start).Seconds(), 'f', -1, 64)
 	return fmt.Sprintln("Everything is cached.  Took " + elapsed + " seconds")

--- a/fwew.go
+++ b/fwew.go
@@ -153,6 +153,7 @@ func clean(searchNaviWords string) (words string) {
 // One Navi-Word can have multiple meanings and words (e.g. synonyms)
 func TranslateFromNaviHash(searchNaviWords string, checkFixes bool) (results [][]Word, err error) {
 	universalLock.Lock()
+	defer universalLock.Unlock()
 	searchNaviWords = clean(searchNaviWords)
 
 	// No Results if empty string after removing sketch chars
@@ -204,7 +205,6 @@ func TranslateFromNaviHash(searchNaviWords string, checkFixes bool) (results [][
 		i += j
 		i++
 	}
-	universalLock.Unlock()
 
 	return
 }
@@ -623,6 +623,7 @@ func SearchNatlangWord(wordmap map[string][]string, searchWord string) (results 
 
 func TranslateToNaviHash(searchWord string, langCode string) (results [][]Word) {
 	universalLock.Lock()
+	defer universalLock.Unlock()
 	searchWord = clean(searchWord)
 
 	results = [][]Word{}
@@ -641,7 +642,6 @@ func TranslateToNaviHash(searchWord string, langCode string) (results [][]Word) 
 		tempResults = append(tempResults, results[len(results)-1]...)
 		results[len(results)-1] = tempResults
 	}
-	universalLock.Unlock()
 	return
 }
 
@@ -885,6 +885,7 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 // One Word can have multiple meanings and words (e.g. synonyms)
 func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode string) (results [][]Word, err error) {
 	universalLock.Lock()
+	defer universalLock.Unlock()
 	searchNaviWords = clean(searchNaviWords)
 
 	// No Results if empty string after removing sketch chars
@@ -924,7 +925,6 @@ func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode strin
 
 		i++
 	}
-	universalLock.Unlock()
 	return
 }
 
@@ -1330,6 +1330,7 @@ func ReefMe(ipa string, inter bool) []string {
 
 func StartEverything() string {
 	universalLock.Lock()
+	defer universalLock.Unlock()
 	start := time.Now()
 	var errors = []error{
 		AssureDict(),
@@ -1344,6 +1345,5 @@ func StartEverything() string {
 	}
 	PhonemeDistros()
 	elapsed := strconv.FormatFloat(time.Since(start).Seconds(), 'f', -1, 64)
-	universalLock.Unlock()
 	return fmt.Sprintln("Everything is cached.  Took " + elapsed + " seconds")
 }

--- a/fwew.go
+++ b/fwew.go
@@ -966,6 +966,8 @@ func Random(amount int, args []string, checkDigraphs uint8) (results []Word, err
 
 // Get all words with spaces
 func GetMultiwordWords() map[string][][]string {
+	universalLock.Lock()
+	defer universalLock.Unlock()
 	return multiword_words
 }
 

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -18,6 +18,7 @@ package fwew_lib
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -772,6 +773,7 @@ func TestTranslateFromNaviCached(t *testing.T) {
 	}
 
 	for _, tt := range naviWords {
+		fmt.Println(tt)
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := TranslateFromNaviHash(tt.args.searchNaviText, true)
 			if err == nil && tt.args.searchNaviText == "" && got != nil {

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -18,7 +18,6 @@ package fwew_lib
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -773,7 +772,6 @@ func TestTranslateFromNaviCached(t *testing.T) {
 	}
 
 	for _, tt := range naviWords {
-		fmt.Println(tt)
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := TranslateFromNaviHash(tt.args.searchNaviText, true)
 			if err == nil && tt.args.searchNaviText == "" && got != nil {

--- a/list.go
+++ b/list.go
@@ -12,6 +12,8 @@ import (
 // It will try to always get 3 args and an `and` in between. If less than 3 exist, than it will wil return the previous
 // results.
 func List(args []string, checkDigraphs uint8) (results []Word, err error) {
+	universalLock.Lock()
+	defer universalLock.Unlock()
 	results, err = GetFullDict()
 
 	if err != nil {

--- a/list.go
+++ b/list.go
@@ -12,8 +12,6 @@ import (
 // It will try to always get 3 args and an `and` in between. If less than 3 exist, than it will wil return the previous
 // results.
 func List(args []string, checkDigraphs uint8) (results []Word, err error) {
-	universalLock.Lock()
-	defer universalLock.Unlock()
 	results, err = GetFullDict()
 
 	if err != nil {

--- a/list_test.go
+++ b/list_test.go
@@ -502,7 +502,7 @@ func TestList(t *testing.T) {
 					PartOfSpeech:   "num.",
 					RU:             "один (число)",
 					SV:             "en, ett",
-					Source:         "NULL",
+					Source:         "https://forum.learnnavi.org/?msg=67090 (2010-01-30)",
 					Stressed:       "1",
 					Syllables:      "'aw",
 					TR:             "bir",

--- a/name_gen.go
+++ b/name_gen.go
@@ -373,8 +373,8 @@ func NameAlu(name_count int, dialect int, syllable_count int, noun_mode int, adj
 }
 
 func GetPhonemeDistrosMap(lang string) (allDistros [][][]string) {
-	universalLock.Lock()
-	defer universalLock.Unlock()
+	phonoLock.Lock()
+	defer phonoLock.Unlock()
 	// Non-English ones were pulled out of Google translate unless it says VERIFIED
 	header_row := map[string][]string{
 		"en": {"Onset", "Nucleus", "Coda"},          // English

--- a/name_gen.go
+++ b/name_gen.go
@@ -35,6 +35,8 @@ func (s Tuples) Less(i, j int) bool {
  * Name generators
  */
 func SingleNames(name_count int, dialect int, syllable_count int) (output string) {
+	universalLock.Lock()
+	defer universalLock.Unlock()
 	// Make sure the numbers are good
 	if name_count > 50 || name_count <= 0 || syllable_count > 4 || syllable_count < 0 {
 		return "Max name count is 50, max syllable count is 4"
@@ -52,6 +54,8 @@ func SingleNames(name_count int, dialect int, syllable_count int) (output string
 }
 
 func FullNames(ending string, name_count int, dialect int, syllable_count [3]int, two_thousand_limit bool) (output string) {
+	universalLock.Lock()
+	defer universalLock.Unlock()
 	// Make sure the numbers are good
 	if name_count > 50 || name_count <= 0 {
 		return "Max name count is 50, max syllable count is 4"
@@ -138,6 +142,10 @@ func NameAlu(name_count int, dialect int, syllable_count int, noun_mode int, adj
 	allNouns, allAdjectives, allVerbs, allTransitiveVerbs := SortedWords()
 
 	output = ""
+
+	// This isn't at the top because SortedWords calls List, which uses the same lock
+	universalLock.Lock()
+	defer universalLock.Unlock()
 
 	for i := 0; i < name_count; i++ {
 		output += glottal_caps(string(single_name_gen(rand_if_zero(syllable_count), dialect)))
@@ -365,6 +373,8 @@ func NameAlu(name_count int, dialect int, syllable_count int, noun_mode int, adj
 }
 
 func GetPhonemeDistrosMap(lang string) (allDistros [][][]string) {
+	universalLock.Lock()
+	defer universalLock.Unlock()
 	// Non-English ones were pulled out of Google translate unless it says VERIFIED
 	header_row := map[string][]string{
 		"en": {"Onset", "Nucleus", "Coda"},          // English

--- a/name_gen_core.go
+++ b/name_gen_core.go
@@ -358,6 +358,8 @@ func convertDialect(word Word, dialect int) string {
 /* Randomly construct a phonotactically valid Na'vi word
  * Dialect codes: 0 is interdialect, 1 is forest, 2 is reef */
 func single_name_gen(syllable_count int, dialect int) (name string) {
+	phonoLock.Lock()
+	defer phonoLock.Unlock()
 	// Sometimes these things might be referenced across loops
 	name = ""
 	onset := ""

--- a/name_gen_core.go
+++ b/name_gen_core.go
@@ -562,6 +562,8 @@ func SortedWords() (nouns []Word, adjectives []Word, verbs []Word, transitiveVer
 
 // Called on startup to feed and compile dictionary information into the name generator
 func PhonemeDistros() {
+	phonoLock.Lock()
+	defer phonoLock.Unlock()
 	// get the dict
 	words, err := List([]string{}, 0)
 


### PR DESCRIPTION
In response to a system crash where both `update()` and `dialectCrunch()` attempted to access `nkxSub` at the same time, here are a few things to make it thread safe:
- Two mutual exclusion locks ensure the dictionary or phoneme counts are accessed by one program at a time.
- When one thread accesses dictionary-related stuff, the others have to wait.  Same for phoneme count related stuff.

Bonus: Multiword words now show up properly in bidirectional search