### PR TITLE
Made it not duplicate results if the natlang and Na'vi dicts contain the same word

### DIFF
--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -225,8 +225,10 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 		return candidates
 	}
 
+	vowels := "aäeiìouù"
+
 	// fneu checking for fne-'u
-	if len(lastPrefix) > 0 && len(input.word) > 0 && is_vowel(nth_rune(lastPrefix, -1)) && is_vowel(nth_rune(input.word, 0)) {
+	if len(lastPrefix) > 0 && len(input.word) > 0 && hasAt(vowels, lastPrefix, -1) && hasAt(vowels, input.word, 0) {
 		if !implContainsAny(prefixes1lenition, []string{lastPrefix}) { // do not do this for leniting prefixes
 			newCandidate := candidateDupe(input)
 			newCandidate.word = "'" + newCandidate.word
@@ -235,7 +237,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 	}
 
 	// fea checkeing for fe'a
-	if len(lastSuffix) > 0 && len(input.word) > 0 && is_vowel(nth_rune(lastSuffix, 0)) && is_vowel(nth_rune(input.word, -1)) {
+	if len(lastSuffix) > 0 && len(input.word) > 0 && hasAt(vowels, lastSuffix, 0) && hasAt(vowels, input.word, -1) {
 		newCandidate := candidateDupe(input)
 		newCandidate.word += "'"
 		deconjugateHelper(newCandidate, prefixCheck, suffixCheck, unlenite, checkInfixes, "", "")

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -398,7 +398,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 				deconjugateHelper(newCandidate, 10, 10, -1, false, element, "")
 
 				// check "tsatan", "tan" and "atan"
-				newCandidate.word = get_last_rune(element, 1) + newCandidate.word
+				newCandidate.word = string(get_last_rune(element, 1)) + newCandidate.word
 				deconjugateHelper(newCandidate, 10, 10, -1, false, element, "")
 			}
 		}
@@ -419,7 +419,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 					deconjugateHelper(newCandidate, 3, suffixCheck, -1, false, element, "")
 
 					// check "tsatan", "tan" and "atan"
-					newCandidate.word = get_last_rune(element, 1) + newString
+					newCandidate.word = string(get_last_rune(element, 1)) + newString
 					deconjugateHelper(newCandidate, 3, suffixCheck, -1, false, element, "")
 				}
 			}
@@ -442,7 +442,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 					// Could it be pekoyu (pe + 'ekoyu, not pe + kxoyu)
 					if hasAt(vowels, element, -1) {
 						// check "pxeyktan", "yktan" and "eyktan"
-						newCandidate.word = get_last_rune(element, 1) + newString
+						newCandidate.word = string(get_last_rune(element, 1)) + newString
 						deconjugateHelper(newCandidate, 4, suffixCheck, -1, false, element, "")
 
 						// check "pxeylan", "ylan" and "'eylan"
@@ -488,7 +488,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 					deconjugateHelper(newCandidate, 5, suffixCheck, -1, false, element, "")
 
 					// check "tsatan", "tan" and "atan"
-					newCandidate.word = get_last_rune(element, 1) + newCandidate.word
+					newCandidate.word = string(get_last_rune(element, 1)) + newCandidate.word
 					deconjugateHelper(newCandidate, 5, suffixCheck, -1, false, element, "")
 				}
 			}
@@ -741,7 +741,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			runes := []rune(input.word)
 			for i, c := range runes {
 				// Infixes can only begin with vowels
-				if has(vowels, c) {
+				if is_vowel(c) {
 					shortString := string(runes[i:])
 					for _, infix := range infixes[c] {
 						if strings.HasPrefix(shortString, infix) {

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -440,7 +440,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 					newCandidate.insistPOS = "n."
 
 					// Could it be pekoyu (pe + 'ekoyu, not pe + kxoyu)
-					if hasAt("aäeiìou", element, -1) {
+					if hasAt(vowels, element, -1) {
 						// check "pxeyktan", "yktan" and "eyktan"
 						newCandidate.word = get_last_rune(element, 1) + newString
 						deconjugateHelper(newCandidate, 4, suffixCheck, -1, false, element, "")
@@ -741,7 +741,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			runes := []rune(input.word)
 			for i, c := range runes {
 				// Infixes can only begin with vowels
-				if has("aäeiìou", c) {
+				if has(vowels, c) {
 					shortString := string(runes[i:])
 					for _, infix := range infixes[c] {
 						if strings.HasPrefix(shortString, infix) {

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -5,22 +5,22 @@ import (
 )
 
 type ConjugationCandidate struct {
-	word      string
-	lenition  []string
-	prefixes  []string
-	suffixes  []string
-	infixes   []string
-	insistPOS string
+	Word      string
+	Lenition  []string
+	Prefixes  []string
+	Suffixes  []string
+	Infixes   []string
+	InsistPOS string
 }
 
 func candidateDupe(candidate ConjugationCandidate) (c ConjugationCandidate) {
 	a := ConjugationCandidate{}
-	a.word = candidate.word
-	a.lenition = candidate.lenition
-	a.prefixes = candidate.prefixes
-	a.infixes = candidate.infixes
-	a.suffixes = candidate.suffixes
-	a.insistPOS = candidate.insistPOS
+	a.Word = candidate.Word
+	a.Lenition = candidate.Lenition
+	a.Prefixes = candidate.Prefixes
+	a.Infixes = candidate.Infixes
+	a.Suffixes = candidate.Suffixes
+	a.InsistPOS = candidate.InsistPOS
 	return a
 }
 
@@ -150,10 +150,10 @@ var weirdNounSuffixes = map[string]string{
 }
 
 func isDuplicate(input ConjugationCandidate) bool {
-	if a, ok := candidateMap[input.word]; ok {
-		if input.insistPOS == a.insistPOS {
-			if len(input.prefixes) == len(a.prefixes) && len(input.suffixes) == len(a.suffixes) {
-				if len(input.infixes) == len(a.infixes) {
+	if a, ok := candidateMap[input.Word]; ok {
+		if input.InsistPOS == a.InsistPOS {
+			if len(input.Prefixes) == len(a.Prefixes) && len(input.Suffixes) == len(a.Suffixes) {
+				if len(input.Infixes) == len(a.Infixes) {
 					return true
 				}
 			}
@@ -228,81 +228,81 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 	vowels := "aäeiìouù"
 
 	// fneu checking for fne-'u
-	if len(lastPrefix) > 0 && len(input.word) > 0 && hasAt(vowels, lastPrefix, -1) && hasAt(vowels, input.word, 0) {
+	if len(lastPrefix) > 0 && len(input.Word) > 0 && hasAt(vowels, lastPrefix, -1) && hasAt(vowels, input.Word, 0) {
 		if !implContainsAny(prefixes1lenition, []string{lastPrefix}) { // do not do this for leniting prefixes
 			newCandidate := candidateDupe(input)
-			newCandidate.word = "'" + newCandidate.word
+			newCandidate.Word = "'" + newCandidate.Word
 			deconjugateHelper(newCandidate, prefixCheck, suffixCheck, unlenite, checkInfixes, "", "")
 		}
 	}
 
 	// fea checkeing for fe'a
-	if len(lastSuffix) > 0 && len(input.word) > 0 && hasAt(vowels, lastSuffix, 0) && hasAt(vowels, input.word, -1) {
+	if len(lastSuffix) > 0 && len(input.Word) > 0 && hasAt(vowels, lastSuffix, 0) && hasAt(vowels, input.Word, -1) {
 		newCandidate := candidateDupe(input)
-		newCandidate.word += "'"
+		newCandidate.Word += "'"
 		deconjugateHelper(newCandidate, prefixCheck, suffixCheck, unlenite, checkInfixes, "", "")
 	}
 
 	// Exceptions for how words conjugate
-	if len(input.suffixes) == 1 {
-		if validWord, ok := weirdNounSuffixes[input.word]; ok {
-			input.word = validWord
+	if len(input.Suffixes) == 1 {
+		if validWord, ok := weirdNounSuffixes[input.Word]; ok {
+			input.Word = validWord
 			if !isDuplicate(input) {
 				candidates = append(candidates, input)
-				candidateMap[input.word] = input
+				candidateMap[input.Word] = input
 			}
 			return candidates
 		}
 	}
 
-	if len(input.infixes) > 0 && implContainsAny(input.infixes, []string{"ats", "uy"}) {
+	if len(input.Infixes) > 0 && implContainsAny(input.Infixes, []string{"ats", "uy"}) {
 		// for the cases of zen<ats>eke and zen<uy>eke
 		// confirmed in here: https://forum.learnnavi.org/index.php?msg=493217
-		if input.word == "zeneke" {
-			input.word = "zenke"
+		if input.Word == "zeneke" {
+			input.Word = "zenke"
 			if !isDuplicate(input) {
 				candidates = append(candidates, input)
-				candidateMap[input.word] = input
+				candidateMap[input.Word] = input
 			}
 			return candidates
 		}
 	}
 
 	candidates = append(candidates, input)
-	candidateMap[input.word] = input
+	candidateMap[input.Word] = input
 
 	// Add a way for e to become ä again if we're down to 1 syllable
-	if len([]rune(input.word)) < 8 && (len(input.prefixes) > 0 || len(input.infixes) > 0 || len(input.suffixes) > 0) && strings.Contains(input.word, "e") {
+	if len([]rune(input.Word)) < 8 && (len(input.Prefixes) > 0 || len(input.Infixes) > 0 || len(input.Suffixes) > 0) && strings.Contains(input.Word, "e") {
 		// could be tskxäpx (7 letters 1 syllable)
 		newCandidate := candidateDupe(input)
-		newCandidate.word = strings.ReplaceAll(newCandidate.word, "e", "ä")
+		newCandidate.Word = strings.ReplaceAll(newCandidate.Word, "e", "ä")
 		deconjugateHelper(newCandidate, prefixCheck, suffixCheck, unlenite, checkInfixes, "", "")
 	}
 
 	newString := ""
 
-	if input.insistPOS == "n." || input.insistPOS == "any" {
+	if input.InsistPOS == "n." || input.InsistPOS == "any" {
 		// For [word] si becoming [word]tswo
-		if strings.HasSuffix(input.word, "tswo") {
+		if strings.HasSuffix(input.Word, "tswo") {
 			newCandidate := candidateDupe(input)
-			newCandidate.word = strings.TrimSuffix(input.word, "tswo") + " si"
-			newCandidate.insistPOS = "v."
-			newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "tswo")
+			newCandidate.Word = strings.TrimSuffix(input.Word, "tswo") + " si"
+			newCandidate.InsistPOS = "v."
+			newCandidate.Suffixes = isDuplicateFix(newCandidate.Suffixes, "tswo")
 			if !isDuplicate(newCandidate) {
 				candidates = append(candidates, newCandidate)
-				candidateMap[input.word] = input
+				candidateMap[input.Word] = input
 			}
 		}
 	}
 
-	if input.insistPOS == "adj." || input.insistPOS == "any" {
+	if input.InsistPOS == "adj." || input.InsistPOS == "any" {
 		// For lrrtok-susi and others
-		if strings.HasSuffix(input.word, "-susi") || strings.HasSuffix(input.word, "-susia") {
+		if strings.HasSuffix(input.Word, "-susi") || strings.HasSuffix(input.Word, "-susia") {
 			found := false
-			trimmedWord := strings.TrimSuffix(input.word, "-susi")
+			trimmedWord := strings.TrimSuffix(input.Word, "-susi")
 			aPosition := 0
-			if strings.HasSuffix(input.word, "-susia") {
-				trimmedWord = strings.TrimSuffix(input.word, "-susia")
+			if strings.HasSuffix(input.Word, "-susia") {
+				trimmedWord = strings.TrimSuffix(input.Word, "-susia")
 				aPosition = 1
 			}
 
@@ -336,24 +336,24 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 
 			if !isDuplicate(input) {
 				candidates = append(candidates, input)
-				candidateMap[input.word] = input
+				candidateMap[input.Word] = input
 			} // to bump the real candidate into recognition
 
 			if found {
 				newCandidate := candidateDupe(input)
-				newCandidate.word = trimmedWord + " si"
+				newCandidate.Word = trimmedWord + " si"
 				if aPosition == -1 {
-					newCandidate.word = strings.TrimPrefix(trimmedWord, "a") + " si"
-					newCandidate.prefixes = append(newCandidate.prefixes, "a")
+					newCandidate.Word = strings.TrimPrefix(trimmedWord, "a") + " si"
+					newCandidate.Prefixes = append(newCandidate.Prefixes, "a")
 				}
-				newCandidate.infixes = []string{"us"}
-				newCandidate.insistPOS = "v."
+				newCandidate.Infixes = []string{"us"}
+				newCandidate.InsistPOS = "v."
 				if aPosition == 1 {
-					newCandidate.suffixes = append(newCandidate.suffixes, "a")
+					newCandidate.Suffixes = append(newCandidate.Suffixes, "a")
 				}
 				if !isDuplicate(newCandidate) {
 					candidates = append(candidates, newCandidate)
-					candidateMap[input.word] = input
+					candidateMap[input.Word] = input
 				}
 			}
 			return candidates
@@ -368,20 +368,20 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 
 	switch prefixCheck {
 	case 0:
-		if strings.HasPrefix(input.word, "a") && input.insistPOS != "n." && !strings.HasPrefix(input.insistPOS, "ad") {
+		if strings.HasPrefix(input.Word, "a") && input.InsistPOS != "n." && !strings.HasPrefix(input.InsistPOS, "ad") {
 			// No nouns, adpositions or adverbs
 			newCandidate := candidateDupe(input)
-			newCandidate.word = input.word[1:]
-			newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "a")
-			newCandidate.insistPOS = "adj."
+			newCandidate.Word = input.Word[1:]
+			newCandidate.Prefixes = isDuplicateFix(newCandidate.Prefixes, "a")
+			newCandidate.InsistPOS = "adj."
 			deconjugateHelper(newCandidate, 1, suffixCheck, -1, false, "a", "")
-			newCandidate.insistPOS = "v."
+			newCandidate.InsistPOS = "v."
 			deconjugateHelper(newCandidate, 1, suffixCheck, -1, true, "a", "")
-		} else if strings.HasPrefix(input.word, "nì") {
+		} else if strings.HasPrefix(input.Word, "nì") {
 			newCandidate := candidateDupe(input)
-			newCandidate.word = strings.TrimPrefix(input.word, "nì")
-			newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "nì")
-			newCandidate.insistPOS = "nì."
+			newCandidate.Word = strings.TrimPrefix(input.Word, "nì")
+			newCandidate.Prefixes = isDuplicateFix(newCandidate.Prefixes, "nì")
+			newCandidate.InsistPOS = "nì."
 			// No other affixes allowed
 			deconjugateHelper(newCandidate, 10, 10, -1, false, "nì", "") // No other fixes
 		}
@@ -389,64 +389,64 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 	case 1:
 		for _, element := range verbPrefixes {
 			// If it has a prefix
-			if strings.HasPrefix(input.word, element) {
+			if strings.HasPrefix(input.Word, element) {
 				// remove it
 				newCandidate := candidateDupe(input)
-				newCandidate.word = strings.TrimPrefix(input.word, element)
-				newCandidate.insistPOS = "v."
-				newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
+				newCandidate.Word = strings.TrimPrefix(input.Word, element)
+				newCandidate.InsistPOS = "v."
+				newCandidate.Prefixes = isDuplicateFix(newCandidate.Prefixes, element)
 				deconjugateHelper(newCandidate, 10, 10, -1, false, element, "")
 
 				// check "tsatan", "tan" and "atan"
-				newCandidate.word = string(get_last_rune(element, 1)) + newCandidate.word
+				newCandidate.Word = string(get_last_rune(element, 1)) + newCandidate.Word
 				deconjugateHelper(newCandidate, 10, 10, -1, false, element, "")
 			}
 		}
 		fallthrough
 	case 2:
 		// Non-lenition prefixes for nouns only
-		if input.insistPOS == "any" || input.insistPOS == "n." {
+		if input.InsistPOS == "any" || input.InsistPOS == "n." {
 			for _, element := range prefixes1Nouns {
 				// If it has a prefix
-				if strings.HasPrefix(input.word, element) {
+				if strings.HasPrefix(input.Word, element) {
 					// remove it
-					newString = strings.TrimPrefix(input.word, element)
+					newString = strings.TrimPrefix(input.Word, element)
 
 					newCandidate := candidateDupe(input)
-					newCandidate.word = newString
-					newCandidate.insistPOS = "n."
-					newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
+					newCandidate.Word = newString
+					newCandidate.InsistPOS = "n."
+					newCandidate.Prefixes = isDuplicateFix(newCandidate.Prefixes, element)
 					deconjugateHelper(newCandidate, 3, suffixCheck, -1, false, element, "")
 
 					// check "tsatan", "tan" and "atan"
-					newCandidate.word = string(get_last_rune(element, 1)) + newString
+					newCandidate.Word = string(get_last_rune(element, 1)) + newString
 					deconjugateHelper(newCandidate, 3, suffixCheck, -1, false, element, "")
 				}
 			}
 		}
 		fallthrough
 	case 3:
-		if input.insistPOS == "any" || input.insistPOS == "n." {
+		if input.InsistPOS == "any" || input.InsistPOS == "n." {
 			// This one will demand this makes it use lenition
 			for _, element := range prefixes1lenition {
 				// If it has a lenition-causing prefix
-				if strings.HasPrefix(input.word, element) {
+				if strings.HasPrefix(input.Word, element) {
 					lenited := false
-					newString = strings.TrimPrefix(input.word, element)
+					newString = strings.TrimPrefix(input.Word, element)
 
 					newCandidate := candidateDupe(input)
-					newCandidate.word = newString
-					newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
-					newCandidate.insistPOS = "n."
+					newCandidate.Word = newString
+					newCandidate.Prefixes = isDuplicateFix(newCandidate.Prefixes, element)
+					newCandidate.InsistPOS = "n."
 
 					// Could it be pekoyu (pe + 'ekoyu, not pe + kxoyu)
 					if hasAt(vowels, element, -1) {
 						// check "pxeyktan", "yktan" and "eyktan"
-						newCandidate.word = string(get_last_rune(element, 1)) + newString
+						newCandidate.Word = string(get_last_rune(element, 1)) + newString
 						deconjugateHelper(newCandidate, 4, suffixCheck, -1, false, element, "")
 
 						// check "pxeylan", "ylan" and "'eylan"
-						newCandidate.word = "'" + newCandidate.word
+						newCandidate.Word = "'" + newCandidate.Word
 						deconjugateHelper(newCandidate, 4, suffixCheck, -1, false, element, "")
 					}
 
@@ -458,9 +458,9 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 							lenited = true
 
 							for _, newPrefix := range unlenition[oldPrefix] {
-								newCandidate.word = newPrefix + strings.TrimPrefix(newString, oldPrefix)
+								newCandidate.Word = newPrefix + strings.TrimPrefix(newString, oldPrefix)
 								if oldPrefix != newPrefix {
-									newCandidate.lenition = []string{newPrefix + "→" + oldPrefix}
+									newCandidate.Lenition = []string{newPrefix + "→" + oldPrefix}
 								}
 								deconjugateHelper(newCandidate, 4, suffixCheck, -1, false, oldPrefix, "")
 							}
@@ -468,7 +468,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 						}
 					}
 					if !lenited {
-						newCandidate.word = newString
+						newCandidate.Word = newString
 						deconjugateHelper(newCandidate, 3, suffixCheck, -1, false, element, "")
 					}
 				}
@@ -476,35 +476,35 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 		}
 		fallthrough
 	case 4:
-		if input.insistPOS == "any" || input.insistPOS == "n." {
+		if input.InsistPOS == "any" || input.InsistPOS == "n." {
 			for _, element := range stemPrefixes {
 				// If it has a prefix
-				if strings.HasPrefix(input.word, element) {
+				if strings.HasPrefix(input.Word, element) {
 					// remove it
 					newCandidate := candidateDupe(input)
-					newCandidate.word = strings.TrimPrefix(input.word, element)
-					newCandidate.insistPOS = "n."
-					newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, element)
+					newCandidate.Word = strings.TrimPrefix(input.Word, element)
+					newCandidate.InsistPOS = "n."
+					newCandidate.Prefixes = isDuplicateFix(newCandidate.Prefixes, element)
 					deconjugateHelper(newCandidate, 5, suffixCheck, -1, false, element, "")
 
 					// check "tsatan", "tan" and "atan"
-					newCandidate.word = string(get_last_rune(element, 1)) + newCandidate.word
+					newCandidate.Word = string(get_last_rune(element, 1)) + newCandidate.Word
 					deconjugateHelper(newCandidate, 5, suffixCheck, -1, false, element, "")
 				}
 			}
 		}
 		fallthrough
 	case 5:
-		if strings.HasPrefix(input.word, "tì") {
-			if input.insistPOS == "any" || input.insistPOS == "n." {
+		if strings.HasPrefix(input.Word, "tì") {
+			if input.InsistPOS == "any" || input.InsistPOS == "n." {
 				// remove it
 				newCandidate := candidateDupe(input)
-				newCandidate.word = strings.TrimPrefix(input.word, "tì")
-				newCandidate.insistPOS = "v."
-				newCandidate.prefixes = isDuplicateFix(newCandidate.prefixes, "tì")
+				newCandidate.Word = strings.TrimPrefix(input.Word, "tì")
+				newCandidate.InsistPOS = "v."
+				newCandidate.Prefixes = isDuplicateFix(newCandidate.Prefixes, "tì")
 				deconjugateHelper(newCandidate, 10, 10, -1, true, "tì", "") // No other prefixes allowed
 
-				newCandidate.word = "ì" + newCandidate.word
+				newCandidate.Word = "ì" + newCandidate.Word
 				deconjugateHelper(newCandidate, 10, 10, -1, true, "tì", "") // Or any additional suffixes
 			}
 		}
@@ -513,26 +513,26 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 	switch suffixCheck {
 	case 0:
 		// Made sì its own suffix and no suffixes can come after it
-		if len(input.suffixes) == 0 && strings.HasSuffix(input.word, "sì") {
+		if len(input.Suffixes) == 0 && strings.HasSuffix(input.Word, "sì") {
 			newCandidate := candidateDupe(input)
-			newCandidate.word = strings.TrimSuffix(newCandidate.word, "sì")
-			newCandidate.suffixes = append(newCandidate.suffixes, "sì")
+			newCandidate.Word = strings.TrimSuffix(newCandidate.Word, "sì")
+			newCandidate.Suffixes = append(newCandidate.Suffixes, "sì")
 			deconjugateHelper(newCandidate, newPrefixCheck, 1, unlenite, checkInfixes, "", "sì")
 		}
 		// special case: short genitives of pronouns like "oey" and "ngey"
-		if input.insistPOS == "any" || input.insistPOS == "n." {
-			if strings.HasSuffix(input.word, "y") {
+		if input.InsistPOS == "any" || input.InsistPOS == "n." {
+			if strings.HasSuffix(input.Word, "y") {
 				// oey to oe
 				newCandidate := candidateDupe(input)
-				newCandidate.word = strings.TrimSuffix(input.word, "y")
-				newCandidate.insistPOS = "pn."
-				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "y")
+				newCandidate.Word = strings.TrimSuffix(input.Word, "y")
+				newCandidate.InsistPOS = "pn."
+				newCandidate.Suffixes = isDuplicateFix(newCandidate.Suffixes, "y")
 				deconjugateHelper(newCandidate, newPrefixCheck, 10, unlenite, false, "", "y")
 
 				// ngey to nga
-				if strings.HasSuffix(newCandidate.word, "e") {
-					newCandidate.word = strings.TrimSuffix(newCandidate.word, "e") + "a"
-					newCandidate.insistPOS = "pn."
+				if strings.HasSuffix(newCandidate.Word, "e") {
+					newCandidate.Word = strings.TrimSuffix(newCandidate.Word, "e") + "a"
+					newCandidate.InsistPOS = "pn."
 					deconjugateHelper(newCandidate, newPrefixCheck, 10, unlenite, false, "", "y")
 				}
 			}
@@ -541,114 +541,114 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 	case 1:
 		for _, oldSuffix := range adposuffixes {
 			// If it has one of them,
-			if strings.HasSuffix(input.word, oldSuffix) {
-				newString = strings.TrimSuffix(input.word, oldSuffix)
+			if strings.HasSuffix(input.Word, oldSuffix) {
+				newString = strings.TrimSuffix(input.Word, oldSuffix)
 
 				newCandidate := candidateDupe(input)
-				newCandidate.word = newString
-				newCandidate.insistPOS = "n."
-				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
+				newCandidate.Word = newString
+				newCandidate.InsistPOS = "n."
+				newCandidate.Suffixes = isDuplicateFix(newCandidate.Suffixes, oldSuffix)
 				// all set to 2 to avoid mengeyä -> mengo -> me + 'eng + o
 				deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", oldSuffix)
 
-				if oldSuffix == "ä" && !strings.HasSuffix(input.word, "yä") && strings.HasSuffix(input.word, "iä") { // Don't make peyä -> yä -> ya (air)
+				if oldSuffix == "ä" && !strings.HasSuffix(input.Word, "yä") && strings.HasSuffix(input.Word, "iä") { // Don't make peyä -> yä -> ya (air)
 					// soaiä, tìftiä, etx.
 					newString += "a"
-					newCandidate.word = newString
+					newCandidate.Word = newString
 					deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", oldSuffix)
-				} else if oldSuffix == "e" && !strings.HasSuffix(input.word, "ye") && strings.HasSuffix(input.word, "ie") {
+				} else if oldSuffix == "e" && !strings.HasSuffix(input.Word, "ye") && strings.HasSuffix(input.Word, "ie") {
 					// reef of above
 					newString += "a"
-					newCandidate.word = newString
+					newCandidate.Word = newString
 					deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", "ä")
 				} else if oldSuffix == "yä" && strings.HasSuffix(newString, "e") {
 					// A one-off
 					if newString == "tse" {
-						newCandidate.word = "tsaw"
+						newCandidate.Word = "tsaw"
 						deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", oldSuffix)
 					}
 					// ngeyä -> nga
-					newCandidate.word = strings.TrimSuffix(newString, "e") + "a"
+					newCandidate.Word = strings.TrimSuffix(newString, "e") + "a"
 					deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", oldSuffix)
 					// oengeyä
-					newCandidate.word = strings.TrimSuffix(newString, "e")
-					if newCandidate.word == "oeng" { //no mengeyä -> meng -> me + 'eng
+					newCandidate.Word = strings.TrimSuffix(newString, "e")
+					if newCandidate.Word == "oeng" { //no mengeyä -> meng -> me + 'eng
 						deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", oldSuffix)
 					}
 					// sneyä -> sno
-					newCandidate.word = strings.TrimSuffix(newString, "e") + "o"
+					newCandidate.Word = strings.TrimSuffix(newString, "e") + "o"
 					deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", oldSuffix)
 				} else if oldSuffix == "ye" && strings.HasSuffix(newString, "e") {
 					// reef of above
 					if newString == "tse" {
-						newCandidate.word = "tsaw"
+						newCandidate.Word = "tsaw"
 						deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", "yä")
 					}
 					// ngeye -> nga
-					newCandidate.word = strings.TrimSuffix(newString, "e") + "a"
+					newCandidate.Word = strings.TrimSuffix(newString, "e") + "a"
 					deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", "yä")
 					// oengeye
-					newCandidate.word = strings.TrimSuffix(newString, "e")
-					if newCandidate.word == "oeng" { //no mengeyä -> meng -> me + 'eng
+					newCandidate.Word = strings.TrimSuffix(newString, "e")
+					if newCandidate.Word == "oeng" { //no mengeyä -> meng -> me + 'eng
 						deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", "yä")
 					}
 					// sneye -> sno
-					newCandidate.word = strings.TrimSuffix(newString, "e") + "o"
+					newCandidate.Word = strings.TrimSuffix(newString, "e") + "o"
 					deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", "yä")
 				} else if vowels, ok := vowelSuffixes["yä"]; ok {
 					for _, vowel := range vowels {
 						// Make sure zekwä-äo is recognized
 						if strings.HasSuffix(newString, vowel+"-") {
 							newString = strings.TrimSuffix(newString, "-")
-							newCandidate.word = newString
+							newCandidate.Word = newString
 							deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", "yä")
 						}
 					}
 				} else {
-					newCandidate.word = strings.TrimSuffix(newString, oldSuffix)
+					newCandidate.Word = strings.TrimSuffix(newString, oldSuffix)
 					deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, false, "", oldSuffix)
 				}
 			}
 		}
 		fallthrough
 	case 2:
-		if input.insistPOS == "any" || input.insistPOS == "n." {
-			if strings.HasSuffix(input.word, "pe") {
-				newString = strings.TrimSuffix(input.word, "pe")
+		if input.InsistPOS == "any" || input.InsistPOS == "n." {
+			if strings.HasSuffix(input.Word, "pe") {
+				newString = strings.TrimSuffix(input.Word, "pe")
 
 				newCandidate := candidateDupe(input)
-				newCandidate.word = newString
-				newCandidate.insistPOS = "n."
-				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "pe")
+				newCandidate.Word = newString
+				newCandidate.InsistPOS = "n."
+				newCandidate.Suffixes = isDuplicateFix(newCandidate.Suffixes, "pe")
 				deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, false, "", "pe")
 			}
 		}
 		fallthrough
 	case 3:
 		// If it has one of them,
-		if strings.HasSuffix(input.word, "a") && input.insistPOS != "n." && !strings.HasPrefix(input.insistPOS, "ad") {
+		if strings.HasSuffix(input.Word, "a") && input.InsistPOS != "n." && !strings.HasPrefix(input.InsistPOS, "ad") {
 			// No nouns, adpositions or adverbs
-			newString = strings.TrimSuffix(input.word, "a")
+			newString = strings.TrimSuffix(input.Word, "a")
 
 			newCandidate := candidateDupe(input)
-			newCandidate.word = newString
-			newCandidate.insistPOS = "adj."
-			newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "a")
+			newCandidate.Word = newString
+			newCandidate.InsistPOS = "adj."
+			newCandidate.Suffixes = isDuplicateFix(newCandidate.Suffixes, "a")
 			deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, true, "", "a")
-			newCandidate.insistPOS = "v."
+			newCandidate.InsistPOS = "v."
 			deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, true, "", "a")
 		}
 
 		fallthrough
 	case 4: // -o suffix "some"
-		if input.insistPOS == "any" || input.insistPOS == "n." {
-			if strings.HasSuffix(input.word, "o") {
-				newString = strings.TrimSuffix(input.word, "o")
+		if input.InsistPOS == "any" || input.InsistPOS == "n." {
+			if strings.HasSuffix(input.Word, "o") {
+				newString = strings.TrimSuffix(input.Word, "o")
 
 				newCandidate := candidateDupe(input)
-				newCandidate.word = newString
-				newCandidate.insistPOS = "n."
-				newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, "o")
+				newCandidate.Word = newString
+				newCandidate.InsistPOS = "n."
+				newCandidate.Suffixes = isDuplicateFix(newCandidate.Suffixes, "o")
 				deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, false, "", "o")
 
 				// Make sure fya'o-o is recognized
@@ -657,7 +657,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 						// Make sure fya'o-o is recognized
 						if strings.HasSuffix(newString, vowel+"-") {
 							newString = strings.TrimSuffix(newString, "-")
-							newCandidate.word = newString
+							newCandidate.Word = newString
 							deconjugateHelper(newCandidate, newPrefixCheck, 5, unlenite, false, "", "o")
 						}
 					}
@@ -666,17 +666,17 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 		}
 		fallthrough
 	case 5:
-		if input.insistPOS == "any" || input.insistPOS == "n." {
+		if input.InsistPOS == "any" || input.InsistPOS == "n." {
 			for _, oldSuffix := range stemSuffixes {
 				// If it has one of them,
-				if strings.HasSuffix(input.word, oldSuffix) {
-					newString = strings.TrimSuffix(input.word, oldSuffix)
+				if strings.HasSuffix(input.Word, oldSuffix) {
+					newString = strings.TrimSuffix(input.Word, oldSuffix)
 
 					//candidates = append(candidates, newString)
 					newCandidate := candidateDupe(input)
-					newCandidate.word = newString
-					newCandidate.insistPOS = "n."
-					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
+					newCandidate.Word = newString
+					newCandidate.InsistPOS = "n."
+					newCandidate.Suffixes = isDuplicateFix(newCandidate.Suffixes, oldSuffix)
 					deconjugateHelper(newCandidate, newPrefixCheck, 6, unlenite, false, "", oldSuffix)
 				}
 			}
@@ -684,22 +684,22 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 		fallthrough
 	case 6:
 		// If it has one of them,
-		if input.insistPOS == "any" || input.insistPOS == "n." {
+		if input.InsistPOS == "any" || input.InsistPOS == "n." {
 			// verb suffixes change things from verbs to nouns, that's why we check for noun status
 			for _, oldSuffix := range verbSuffixes {
 				// If it has one of them,
-				if strings.HasSuffix(input.word, oldSuffix) {
-					newString = strings.TrimSuffix(input.word, oldSuffix)
+				if strings.HasSuffix(input.Word, oldSuffix) {
+					newString = strings.TrimSuffix(input.Word, oldSuffix)
 					newCandidate := candidateDupe(input)
-					newCandidate.word = newString
-					newCandidate.insistPOS = "v."
+					newCandidate.Word = newString
+					newCandidate.InsistPOS = "v."
 
-					newCandidate.suffixes = isDuplicateFix(newCandidate.suffixes, oldSuffix)
+					newCandidate.Suffixes = isDuplicateFix(newCandidate.Suffixes, oldSuffix)
 					deconjugateHelper(newCandidate, 10, 10, unlenite, false, "", oldSuffix) // Don't allow any other prefixes
-					// They may turn the insistPOS back into a noun
+					// They may turn the InsistPOS back into a noun
 
 					if oldSuffix == "yu" && strings.HasSuffix(newString, "si") {
-						newCandidate.word = strings.TrimSuffix(newString, "si") + " si"
+						newCandidate.Word = strings.TrimSuffix(newString, "si") + " si"
 						deconjugateHelper(newCandidate, 10, 10, unlenite, false, "", oldSuffix) // don't allow any other prefixes or suffixes
 					}
 				}
@@ -711,14 +711,14 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 	if unlenite != -1 {
 		for _, oldPrefix := range unlenitionLetters {
 			// If it has a letter that could have changed for lenition,
-			if strings.HasPrefix(input.word, oldPrefix) {
+			if strings.HasPrefix(input.Word, oldPrefix) {
 				// put all possibilities in the candidates
 				for _, newPrefix := range unlenition[oldPrefix] {
 					newCandidate := candidateDupe(input)
-					newString = newPrefix + strings.TrimPrefix(input.word, oldPrefix)
-					newCandidate.word = newString
+					newString = newPrefix + strings.TrimPrefix(input.Word, oldPrefix)
+					newCandidate.Word = newString
 					if oldPrefix != newPrefix {
-						newCandidate.lenition = []string{newPrefix + "→" + oldPrefix}
+						newCandidate.Lenition = []string{newPrefix + "→" + oldPrefix}
 					}
 					deconjugateHelper(newCandidate, prefixCheck, suffixCheck, -1, false, "", "")
 				}
@@ -727,18 +727,18 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 		}
 	}
 
-	if checkInfixes && len(input.infixes) < 3 {
+	if checkInfixes && len(input.Infixes) < 3 {
 		// Maybe someone else came in with stripped infixes
-		if len(input.word) > 2 && input.word[len(input.word)-3] != ' ' &&
-			strings.HasSuffix(input.word, "si") && !strings.HasSuffix(input.word, "usi") &&
-			!strings.HasSuffix(input.word, "atsi") {
+		if len(input.Word) > 2 && input.Word[len(input.Word)-3] != ' ' &&
+			strings.HasSuffix(input.Word, "si") && !strings.HasSuffix(input.Word, "usi") &&
+			!strings.HasSuffix(input.Word, "atsi") {
 			newCandidate := candidateDupe(input)
-			newCandidate.word = strings.TrimSuffix(input.word, "si") + " si"
-			newCandidate.insistPOS = "v."
+			newCandidate.Word = strings.TrimSuffix(input.Word, "si") + " si"
+			newCandidate.InsistPOS = "v."
 			deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true, "", "")
 		} else { // If there is a "si", we don't need to check for infixes
 			// Check for infixes
-			runes := []rune(input.word)
+			runes := []rune(input.Word)
 			for i, c := range runes {
 				// Infixes can only begin with vowels
 				if is_vowel(c) {
@@ -746,22 +746,22 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 					for _, infix := range infixes[c] {
 						if strings.HasPrefix(shortString, infix) {
 							newCandidate := candidateDupe(input)
-							newCandidate.word = string(runes[:i]) + strings.TrimPrefix(shortString, infix)
-							newCandidate.infixes = isDuplicateFix(newCandidate.infixes, infix)
-							newCandidate.insistPOS = "v."
+							newCandidate.Word = string(runes[:i]) + strings.TrimPrefix(shortString, infix)
+							newCandidate.Infixes = isDuplicateFix(newCandidate.Infixes, infix)
+							newCandidate.InsistPOS = "v."
 							deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true, "", "")
 
 							if infix == "ol" {
 								newCandidate := candidateDupe(input)
-								newCandidate.word = string(runes[:i]) + "ll" + strings.TrimPrefix(shortString, infix)
-								newCandidate.infixes = isDuplicateFix(newCandidate.infixes, infix)
-								newCandidate.insistPOS = "v."
+								newCandidate.Word = string(runes[:i]) + "ll" + strings.TrimPrefix(shortString, infix)
+								newCandidate.Infixes = isDuplicateFix(newCandidate.Infixes, infix)
+								newCandidate.InsistPOS = "v."
 								deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true, "", "")
 							} else if infix == "er" {
 								newCandidate := candidateDupe(input)
-								newCandidate.word = string(runes[:i]) + "rr" + strings.TrimPrefix(shortString, infix)
-								newCandidate.infixes = isDuplicateFix(newCandidate.infixes, infix)
-								newCandidate.insistPOS = "v."
+								newCandidate.Word = string(runes[:i]) + "rr" + strings.TrimPrefix(shortString, infix)
+								newCandidate.Infixes = isDuplicateFix(newCandidate.Infixes, infix)
+								newCandidate.InsistPOS = "v."
 								deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, true, "", "")
 							}
 						}
@@ -773,21 +773,21 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 	return candidates
 }
 
-func deconjugate(input string) []ConjugationCandidate {
+func Deconjugate(input string) []ConjugationCandidate {
 	candidates = []ConjugationCandidate{} //empty array of strings
 	candidateMap = map[string]ConjugationCandidate{}
 	newCandidate := ConjugationCandidate{}
-	newCandidate.word = input
-	newCandidate.insistPOS = "any"
+	newCandidate.Word = input
+	newCandidate.InsistPOS = "any"
 	deconjugateHelper(newCandidate, 0, 0, 0, true, "", "")
 	candidates = candidates[1:]
 	return candidates
 }
 
 func TestDeconjugations(searchNaviWord string) (results []Word) {
-	conjugations := deconjugate(searchNaviWord)
+	conjugations := Deconjugate(searchNaviWord)
 	for _, candidate := range conjugations {
-		a := strings.ReplaceAll(candidate.word, "ù", "u")
+		a := strings.ReplaceAll(candidate.Word, "ù", "u")
 		standardizedWordArray := dialectCrunch(strings.Split(a, " "), false)
 		a = ""
 		for i, b := range standardizedWordArray {
@@ -802,7 +802,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 				pos = strings.ReplaceAll(pos, " ", "")
 
 				// An inter. can act like a noun or an adjective, so it gets special treatment
-				if pos == "inter." && candidate.insistPOS[0] != 'v' && len(candidate.infixes) == 0 {
+				if pos == "inter." && candidate.InsistPOS[0] != 'v' && len(candidate.Infixes) == 0 {
 					dupe := false
 					for _, b := range results {
 						if b.Navi == c.Navi {
@@ -812,10 +812,10 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 					}
 					if !dupe {
 						a := c
-						a.Affixes.Lenition = candidate.lenition
-						a.Affixes.Prefix = candidate.prefixes
-						a.Affixes.Infix = candidate.infixes
-						a.Affixes.Suffix = candidate.suffixes
+						a.Affixes.Lenition = candidate.Lenition
+						a.Affixes.Prefix = candidate.Prefixes
+						a.Affixes.Infix = candidate.Infixes
+						a.Affixes.Suffix = candidate.Suffixes
 						results = AppendAndAlphabetize(results, a)
 						continue
 					}
@@ -829,10 +829,10 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 				participle := false
 
 				// Find gerunds (tì-v<us>erb, the act of [verb]ing)
-				if len(candidate.infixes) == 1 && candidate.infixes[0] == "us" {
+				if len(candidate.Infixes) == 1 && candidate.Infixes[0] == "us" {
 					// Reverse search is more likely to find it immediately
-					for i := len(candidate.prefixes) - 1; i >= 0; i-- {
-						if candidate.prefixes[i] == "tì" {
+					for i := len(candidate.Prefixes) - 1; i >= 0; i-- {
+						if candidate.Prefixes[i] == "tì" {
 							gerund = true
 							break
 						}
@@ -840,31 +840,31 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 					if !gerund {
 						participle = true
 					}
-				} else if len(candidate.infixes) > 0 {
+				} else if len(candidate.Infixes) > 0 {
 					// Now reverse search is just gratuitous
-					for i := len(candidate.infixes) - 1; i >= 0; i-- {
-						if candidate.infixes[i] == "us" || candidate.infixes[i] == "awn" {
+					for i := len(candidate.Infixes) - 1; i >= 0; i-- {
+						if candidate.Infixes[i] == "us" || candidate.Infixes[i] == "awn" {
 							participle = true
 							break
 						}
 					}
 				}
 
-				// If the insistPOS and found word agree they are nouns
-				if len(candidate.suffixes) < 3 && len(candidate.suffixes) > 0 && candidate.suffixes[0] == "tswo" {
+				// If the InsistPOS and found word agree they are nouns
+				if len(candidate.Suffixes) < 3 && len(candidate.Suffixes) > 0 && candidate.Suffixes[0] == "tswo" {
 					if pos[0] == 'v' {
 						siVerb := false
-						if len(candidate.infixes) == 0 {
-							if _, ok := multiword_words[candidate.word]; ok {
-								for _, b := range multiword_words[candidate.word] {
+						if len(candidate.Infixes) == 0 {
+							if _, ok := multiword_words[candidate.Word]; ok {
+								for _, b := range multiword_words[candidate.Word] {
 									if b[0] == "si" {
 										siVerb = true
 										a := c
-										a.Navi = candidate.word + " si"
-										a.Affixes.Lenition = candidate.lenition
-										a.Affixes.Prefix = candidate.prefixes
-										a.Affixes.Infix = candidate.infixes
-										a.Affixes.Suffix = candidate.suffixes
+										a.Navi = candidate.Word + " si"
+										a.Affixes.Lenition = candidate.Lenition
+										a.Affixes.Prefix = candidate.Prefixes
+										a.Affixes.Infix = candidate.Infixes
+										a.Affixes.Suffix = candidate.Suffixes
 										results = AppendAndAlphabetize(results, a)
 										break
 									}
@@ -872,11 +872,11 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 							}
 							if !siVerb {
 								a := c
-								a.Navi = candidate.word
-								a.Affixes.Lenition = candidate.lenition
-								a.Affixes.Prefix = candidate.prefixes
-								a.Affixes.Infix = candidate.infixes
-								a.Affixes.Suffix = candidate.suffixes
+								a.Navi = candidate.Word
+								a.Affixes.Lenition = candidate.Lenition
+								a.Affixes.Prefix = candidate.Prefixes
+								a.Affixes.Infix = candidate.Infixes
+								a.Affixes.Suffix = candidate.Suffixes
 								results = AppendAndAlphabetize(results, a)
 							}
 						}
@@ -892,59 +892,59 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						noTìftang := strings.TrimPrefix(rebuiltVerb, "'")
 						if strings.Contains(searchNaviWord, noTìftang) || strings.Contains(searchNaviWord, dialectCrunch([]string{rebuiltVerb}, false)[0]) {
 							a := c
-							a.Affixes.Lenition = candidate.lenition
-							a.Affixes.Prefix = candidate.prefixes
-							a.Affixes.Infix = candidate.infixes
-							a.Affixes.Suffix = candidate.suffixes
+							a.Affixes.Lenition = candidate.Lenition
+							a.Affixes.Prefix = candidate.Prefixes
+							a.Affixes.Infix = candidate.Infixes
+							a.Affixes.Suffix = candidate.Suffixes
 							results = AppendAndAlphabetize(results, a)
 						} else if len(results) == 0 {
 							results = AppendAndAlphabetize(results, infixError(searchNaviWord, "tì"+rebuiltVerb, c.IPA))
 						}
 					}
-				} else if candidate.insistPOS == "n." {
+				} else if candidate.InsistPOS == "n." {
 					// n., pn., Prop.n. and inter. (but not vin.)
-					if len(candidate.infixes) == 0 {
+					if len(candidate.Infixes) == 0 {
 						if (pos[0] != 'v' && strings.HasSuffix(pos, "n.")) || pos == "inter." {
 							a := c
-							a.Affixes.Lenition = candidate.lenition
-							a.Affixes.Prefix = candidate.prefixes
-							a.Affixes.Suffix = candidate.suffixes
+							a.Affixes.Lenition = candidate.Lenition
+							a.Affixes.Prefix = candidate.Prefixes
+							a.Affixes.Suffix = candidate.Suffixes
 							results = AppendAndAlphabetize(results, a)
 						}
 					}
-				} else if candidate.insistPOS == "pn." {
+				} else if candidate.InsistPOS == "pn." {
 					// pn.
-					if len(candidate.infixes) == 0 && strings.HasSuffix(pos, "pn.") {
+					if len(candidate.Infixes) == 0 && strings.HasSuffix(pos, "pn.") {
 						a := c
-						a.Affixes.Lenition = candidate.lenition
-						a.Affixes.Prefix = candidate.prefixes
-						a.Affixes.Suffix = candidate.suffixes
+						a.Affixes.Lenition = candidate.Lenition
+						a.Affixes.Prefix = candidate.Prefixes
+						a.Affixes.Suffix = candidate.Suffixes
 						results = AppendAndAlphabetize(results, a)
 					}
-				} else if candidate.insistPOS == "adj." {
+				} else if candidate.InsistPOS == "adj." {
 					posNoun := pos
-					if len(candidate.infixes) == 0 && (posNoun == "adj." || posNoun == "num.") {
+					if len(candidate.Infixes) == 0 && (posNoun == "adj." || posNoun == "num.") {
 						a := c
-						a.Affixes.Lenition = candidate.lenition
-						a.Affixes.Prefix = candidate.prefixes
-						a.Affixes.Suffix = candidate.suffixes
+						a.Affixes.Lenition = candidate.Lenition
+						a.Affixes.Prefix = candidate.Prefixes
+						a.Affixes.Suffix = candidate.Suffixes
 						results = AppendAndAlphabetize(results, a)
 					}
-				} else if candidate.insistPOS == "v." {
+				} else if candidate.InsistPOS == "v." {
 					posNoun := pos
 					if strings.HasPrefix(posNoun, "v") {
 						// Verbs with -tswo or -yu cannot have infixes
-						if len(candidate.suffixes) > 0 {
-							for i := len(candidate.suffixes) - 1; i >= 0; i-- {
-								if candidate.suffixes[i] == "a" {
+						if len(candidate.Suffixes) > 0 {
+							for i := len(candidate.Suffixes) - 1; i >= 0; i-- {
+								if candidate.Suffixes[i] == "a" {
 									attributed = true
 									break
 								}
 							}
 							// Forward search fixs the "a" before "yu" and "tswo"
-							for i := len(candidate.suffixes) - 1; i >= 0; i-- {
+							for i := len(candidate.Suffixes) - 1; i >= 0; i-- {
 								for _, j := range verbSuffixes {
-									if candidate.suffixes[i] == j {
+									if candidate.Suffixes[i] == j {
 										infixBan = true
 										break
 									}
@@ -959,18 +959,18 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						looseTì := false
 						tsuk := false
 
-						if len(candidate.prefixes) > 0 {
+						if len(candidate.Prefixes) > 0 {
 							// Reverse search is more likely to find it immediately
-							for i := len(candidate.prefixes) - 1; i >= 0; i-- {
-								if candidate.prefixes[i] == "a" {
+							for i := len(candidate.Prefixes) - 1; i >= 0; i-- {
+								if candidate.Prefixes[i] == "a" {
 									attributed = true
-								} else if candidate.prefixes[i] == "tì" {
+								} else if candidate.Prefixes[i] == "tì" {
 									// we found gerunds up top, so this isn't needed
 									looseTì = true
 									break
 								} else {
 									for _, j := range verbPrefixes {
-										if candidate.prefixes[i] == j {
+										if candidate.Prefixes[i] == j {
 											if infixBan {
 												doubleBan = true
 												break
@@ -989,7 +989,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						}
 
 						// Don't want a[verb] and [verb]a
-						if attributed && (len(candidate.infixes) == 0 || infixBan) && !tsuk {
+						if attributed && (len(candidate.Infixes) == 0 || infixBan) && !tsuk {
 							continue
 						}
 
@@ -999,13 +999,13 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						}
 
 						a := c
-						a.Affixes.Lenition = candidate.lenition
-						a.Affixes.Prefix = candidate.prefixes
-						a.Affixes.Suffix = candidate.suffixes
-						a.Affixes.Infix = candidate.infixes
+						a.Affixes.Lenition = candidate.Lenition
+						a.Affixes.Prefix = candidate.Prefixes
+						a.Affixes.Suffix = candidate.Suffixes
+						a.Affixes.Infix = candidate.Infixes
 
 						if infixBan {
-							if len(candidate.infixes) > 0 {
+							if len(candidate.Infixes) > 0 {
 								continue // No nonsense here
 							} else {
 								results = AppendAndAlphabetize(results, a)
@@ -1018,18 +1018,18 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 
 						// pre-first position infixes
 						rebuiltVerb := c.InfixLocations
-						if c.InfixLocations == "z<0><1>en<2>ke" && implContainsAny(candidate.infixes, []string{"ats", "uy"}) {
+						if c.InfixLocations == "z<0><1>en<2>ke" && implContainsAny(candidate.Infixes, []string{"ats", "uy"}) {
 							rebuiltVerb = "z<0><1>en<2>eke"
 						}
 						firstInfixes := ""
 
-						for _, newInfix := range candidate.infixes {
+						for _, newInfix := range candidate.Infixes {
 							if implContainsAny(prefirst, []string{newInfix}) {
 								firstInfixes += newInfix
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<0>", firstInfixes)
 								if newInfix == "epeyk" || newInfix == "äpeyk" {
 									newCandidateInfixes := []string{}
-									for _, newInfix2 := range candidate.infixes {
+									for _, newInfix2 := range candidate.Infixes {
 										// äpeyk gets split
 										if newInfix2 == "epeyk" || newInfix2 == "äpeyk" {
 											newCandidateInfixes = append(newCandidateInfixes, "äp")
@@ -1047,7 +1047,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 
 						// first position infixes
 						firstInfixes = ""
-						for _, newInfix := range candidate.infixes {
+						for _, newInfix := range candidate.Infixes {
 							if implContainsAny(first, []string{newInfix}) {
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<1>", newInfix)
 								firstInfixes = newInfix
@@ -1062,7 +1062,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<1>", "")
 
 						// second position infixes
-						for _, newInfix := range candidate.infixes {
+						for _, newInfix := range candidate.Infixes {
 							if newInfix == "eng" {
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<2>", "äng")
 								break
@@ -1092,7 +1092,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 							rebuiltVerb += x
 						}
 
-						if len(candidate.infixes) == 0 || identicalRunes(rebuiltVerb, strings.ReplaceAll(searchNaviWord, "-", " ")) {
+						if len(candidate.Infixes) == 0 || identicalRunes(rebuiltVerb, strings.ReplaceAll(searchNaviWord, "-", " ")) {
 							results = AppendAndAlphabetize(results, a)
 						} else if participle {
 							// In case we have a [word]-susi
@@ -1124,20 +1124,20 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 							}
 						}
 					}
-				} else if candidate.insistPOS == "nì." {
+				} else if candidate.InsistPOS == "nì." {
 					posNoun := pos
-					if len(candidate.infixes) == 0 && (posNoun == "adj." || posNoun == "pn.") {
+					if len(candidate.Infixes) == 0 && (posNoun == "adj." || posNoun == "pn.") {
 						a := c
-						a.Affixes.Lenition = candidate.lenition
-						a.Affixes.Prefix = candidate.prefixes
-						a.Affixes.Suffix = candidate.suffixes
+						a.Affixes.Lenition = candidate.Lenition
+						a.Affixes.Prefix = candidate.Prefixes
+						a.Affixes.Suffix = candidate.Suffixes
 						results = AppendAndAlphabetize(results, a)
 					}
-				} else if len(candidate.infixes) == 0 {
+				} else if len(candidate.Infixes) == 0 {
 					a := c
-					a.Affixes.Lenition = candidate.lenition
-					a.Affixes.Prefix = candidate.prefixes
-					a.Affixes.Suffix = candidate.suffixes
+					a.Affixes.Lenition = candidate.Lenition
+					a.Affixes.Prefix = candidate.Prefixes
+					a.Affixes.Suffix = candidate.Suffixes
 					results = AppendAndAlphabetize(results, a)
 				}
 			}

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -438,7 +438,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 					newCandidate.insistPOS = "n."
 
 					// Could it be pekoyu (pe + 'ekoyu, not pe + kxoyu)
-					if has("aäeiìou", get_last_rune(element, 1)) {
+					if hasAt("aäeiìou", element, -1) {
 						// check "pxeyktan", "yktan" and "eyktan"
 						newCandidate.word = get_last_rune(element, 1) + newString
 						deconjugateHelper(newCandidate, 4, suffixCheck, -1, false, element, "")
@@ -739,7 +739,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			runes := []rune(input.word)
 			for i, c := range runes {
 				// Infixes can only begin with vowels
-				if has("aäeiìou", string(c)) {
+				if has("aäeiìou", c) {
 					shortString := string(runes[i:])
 					for _, infix := range infixes[c] {
 						if strings.HasPrefix(shortString, infix) {

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -888,7 +888,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 
 						// Does the noun actually contain the verb?
 						noTìftang := strings.TrimPrefix(rebuiltVerb, "'")
-						if strings.Contains(searchNaviWord, noTìftang) || strings.Contains(searchNaviWord, strings.ReplaceAll(rebuiltVerb, "ä", "e")) {
+						if strings.Contains(searchNaviWord, noTìftang) || strings.Contains(searchNaviWord, dialectCrunch([]string{rebuiltVerb}, false)[0]) {
 							a := c
 							a.Affixes.Lenition = candidate.lenition
 							a.Affixes.Prefix = candidate.prefixes

--- a/cache.go
+++ b/cache.go
@@ -316,7 +316,7 @@ func RomanizeSecondIPA(IPA string) string {
 				// ts
 				breakdown += "ts"
 				//tsp
-				if has("ptk", nth_rune(syllable, 3)) {
+				if hasAt("ptk", syllable, 3) {
 					if nth_rune(syllable, 4) == "'" {
 						// ts + ejective onset
 						breakdown += romanization2[syllable[4:6]]
@@ -326,7 +326,7 @@ func RomanizeSecondIPA(IPA string) string {
 						breakdown += romanization2[string(syllable[4])]
 						syllable = syllable[5:]
 					}
-				} else if has("lɾmnŋwj", nth_rune(syllable, 3)) {
+				} else if hasAt("lɾmnŋwj", syllable, 3) {
 					// ts + other consonent
 					breakdown += romanization2[nth_rune(syllable, 3)]
 					syllable = syllable[4+len(nth_rune(syllable, 3)):]
@@ -334,10 +334,10 @@ func RomanizeSecondIPA(IPA string) string {
 					// ts without a cluster
 					syllable = syllable[4:]
 				}
-			} else if has("fs", nth_rune(syllable, 0)) {
+			} else if hasAt("fs", syllable, 0) {
 				//
 				breakdown += nth_rune(syllable, 0)
-				if has("ptk", nth_rune(syllable, 1)) {
+				if hasAt("ptk", syllable, 1) {
 					if nth_rune(syllable, 2) == "'" {
 						// f/s + ejective onset
 						breakdown += romanization2[syllable[1:3]]
@@ -347,7 +347,7 @@ func RomanizeSecondIPA(IPA string) string {
 						breakdown += romanization2[string(syllable[1])]
 						syllable = syllable[2:]
 					}
-				} else if has("lɾmnŋwj", nth_rune(syllable, 1)) {
+				} else if hasAt("lɾmnŋwj", syllable, 1) {
 					// f/s + other consonent
 					breakdown += romanization2[nth_rune(syllable, 1)]
 					syllable = syllable[1+len(nth_rune(syllable, 1)):]
@@ -355,7 +355,7 @@ func RomanizeSecondIPA(IPA string) string {
 					// f/s without a cluster
 					syllable = syllable[1:]
 				}
-			} else if has("ptk", nth_rune(syllable, 0)) {
+			} else if hasAt("ptk", syllable, 0) {
 				if nth_rune(syllable, 1) == "'" {
 					// ejective
 					breakdown += romanization2[syllable[0:2]]
@@ -365,11 +365,11 @@ func RomanizeSecondIPA(IPA string) string {
 					breakdown += romanization2[string(syllable[0])]
 					syllable = syllable[1:]
 				}
-			} else if has("ʔlɾhmnŋvwjzbdg", nth_rune(syllable, 0)) {
+			} else if hasAt("ʔlɾhmnŋvwjzbdg", syllable, 0) {
 				// other normal onset
 				breakdown += romanization2[nth_rune(syllable, 0)]
 				syllable = syllable[len(nth_rune(syllable, 0)):]
-			} else if has("ʃʒ", nth_rune(syllable, 0)) {
+			} else if hasAt("ʃʒ", syllable, 0) {
 				// one sound representd as a cluster
 				if nth_rune(syllable, 0) == "ʃ" {
 					breakdown += "sh"
@@ -380,11 +380,11 @@ func RomanizeSecondIPA(IPA string) string {
 			/*
 			 * Nucleus
 			 */
-			if len(syllable) > 1 && has("jw", nth_rune(syllable, 1)) {
+			if len(syllable) > 1 && hasAt("jw", syllable, 1) {
 				//diphthong
 				breakdown += romanization2[syllable[0:len(nth_rune(syllable, 0))+1]]
 				syllable = string([]rune(syllable)[2:])
-			} else if len(syllable) > 1 && has("lr", nth_rune(syllable, 0)) {
+			} else if len(syllable) > 1 && hasAt("lr", syllable, 0) {
 				breakdown += romanization2[syllable[0:3]]
 				continue
 			} else {

--- a/cache.go
+++ b/cache.go
@@ -206,75 +206,80 @@ func AppendAndAlphabetize(words []Word, word Word) []Word {
 	return newWords
 }
 
+// Helper to find empty definitions
+func NullDef(definition string) bool {
+	return strings.ToUpper(definition) == "NULL" || len(strings.Trim(definition, " ")) < 1
+}
+
 // If a definition is not available in a certain language, default to English
 func EnglishIfNull(word Word) Word {
 	// English
-	if word.EN == "NULL" {
+	if NullDef(word.EN) {
 		word.EN = "(no definition)"
 	}
 
 	// German (Deutsch)
-	if word.DE == "NULL" {
+	if NullDef(word.DE) {
 		word.DE = word.EN
 	}
 
 	// Spanish (Español)
-	if word.ES == "NULL" {
+	if NullDef(word.ES) {
 		word.ES = word.EN
 	}
 
 	// Estonian (Eesti)
-	if word.ET == "NULL" {
+	if NullDef(word.ET) {
 		word.ET = word.EN
 	}
 
 	// French (Français)
-	if word.FR == "NULL" {
+	if NullDef(word.FR) {
 		word.FR = word.EN
 	}
 
 	// Hungarian (Magyar)
-	if word.HU == "NULL" {
+	if NullDef(word.HU) {
 		word.HU = word.EN
 	}
 
 	// Korean (한국어)
-	if word.KO == "NULL" {
+	if NullDef(word.KO) {
 		word.KO = word.EN
 	}
 
 	// Dutch (Nederlands)
-	if word.NL == "NULL" {
+	if NullDef(word.NL) {
 		word.NL = word.EN
 	}
 
 	// Polish (Polski)
-	if word.PL == "NULL" {
+	if NullDef(word.PL) {
 		word.PL = word.EN
 	}
 
 	// Portuguese (Português)
-	if word.PT == "NULL" {
+	if NullDef(word.PT) {
 		word.PT = word.EN
 	}
 
 	// Russian (Русский)
-	if word.RU == "NULL" {
+	if NullDef(word.RU) {
 		word.RU = word.EN
 	}
 
 	// Swedish (Svenska)
-	if word.SV == "NULL" {
+	if NullDef(word.SV) {
 		word.SV = word.EN
 	}
 
 	// Turkish (Türkçe)
-	if word.TR == "NULL" {
+	if NullDef(word.TR) {
 		word.TR = word.EN
 	}
 
 	// Ukrainian (Українська)
-	if word.UK == "NULL" {
+	if NullDef(word.UK) {
 		word.UK = word.EN
 	}
 
@@ -707,72 +712,72 @@ func CacheDictHash2Orig(mysql bool) error {
 		}
 
 		// English
-		if word.EN != "NULL" {
+		if !NullDef(word.EN) {
 			dictHash2.EN = AssignWord(dictHash2.EN, word.EN, standardizedWord)
 		}
 
 		// German (Deutsch)
-		if word.DE != "NULL" {
+		if !NullDef(word.DE) {
 			dictHash2.DE = AssignWord(dictHash2.DE, word.DE, standardizedWord)
 		}
 
 		// Spanish (Español)
-		if word.ES != "NULL" {
+		if !NullDef(word.ES) {
 			dictHash2.ES = AssignWord(dictHash2.ES, word.ES, standardizedWord)
 		}
 
 		// Estonian (Eesti)
-		if word.ET != "NULL" {
+		if !NullDef(word.ET) {
 			dictHash2.ET = AssignWord(dictHash2.ET, word.ET, standardizedWord)
 		}
 
 		// French (Français)
-		if word.FR != "NULL" {
+		if !NullDef(word.FR) {
 			dictHash2.FR = AssignWord(dictHash2.FR, word.FR, standardizedWord)
 		}
 
 		// Hungarian (Magyar)
-		if word.HU != "NULL" {
+		if !NullDef(word.HU) {
 			dictHash2.HU = AssignWord(dictHash2.HU, word.HU, standardizedWord)
 		}
 
 		// Korean (한국어)
-		if word.KO != "NULL" {
+		if !NullDef(word.KO) {
 			dictHash2.KO = AssignWord(dictHash2.KO, word.KO, standardizedWord)
 		}
 
 		// Dutch (Nederlands)
-		if word.NL != "NULL" {
+		if !NullDef(word.NL) {
 			dictHash2.NL = AssignWord(dictHash2.NL, word.NL, standardizedWord)
 		}
 
 		// Polish (Polski)
-		if word.PL != "NULL" {
+		if !NullDef(word.PL) {
 			dictHash2.PL = AssignWord(dictHash2.PL, word.PL, standardizedWord)
 		}
 
 		// Portuguese (Português)
-		if word.PT != "NULL" {
+		if !NullDef(word.PT) {
 			dictHash2.PT = AssignWord(dictHash2.PT, word.PT, standardizedWord)
 		}
 
 		// Russian (Русский)
-		if word.RU != "NULL" {
+		if !NullDef(word.RU) {
 			dictHash2.RU = AssignWord(dictHash2.RU, word.RU, standardizedWord)
 		}
 
 		// Swedish (Svenska)
-		if word.SV != "NULL" {
+		if !NullDef(word.SV) {
 			dictHash2.SV = AssignWord(dictHash2.SV, word.SV, standardizedWord)
 		}
 
 		// Turkish (Türkçe)
-		if word.TR != "NULL" {
+		if !NullDef(word.TR) {
 			dictHash2.TR = AssignWord(dictHash2.TR, word.TR, standardizedWord)
 		}
 
 		// Ukrainian (Українська)
-		if word.UK != "NULL" {
+		if !NullDef(word.UK) {
 			dictHash2.UK = AssignWord(dictHash2.UK, word.UK, standardizedWord)
 		}
 		return nil

--- a/fwew.go
+++ b/fwew.go
@@ -1044,7 +1044,7 @@ func dialectCrunch(query []string, guaranteedForest bool) []string {
 			if strings.Contains(a, b) {
 				nucleusCount += strings.Count(a, b)
 				for _, c := range []string{"a", "ä", "e", "i", "ì", "o", "u", "ù", "ll", "rr"} {
-					if is_vowel(b) && is_vowel(c) {
+					if b != "ll" && c != "ll" && b != "rr" && c != "rr" {
 						a = strings.ReplaceAll(a, b+"'"+c, b+c)
 					}
 				}

--- a/fwew.go
+++ b/fwew.go
@@ -1198,7 +1198,7 @@ func ReefMe(ipa string, inter bool) []string {
 				// ts
 				breakdown += "ts"
 				//tsp
-				if has("ptk", nth_rune(syllable, 3)) {
+				if hasAt("ptk", syllable, 3) {
 					if nth_rune(syllable, 4) == "'" {
 						// ts + ejective onset
 						breakdown += romanization2[syllable[4:6]]
@@ -1208,7 +1208,7 @@ func ReefMe(ipa string, inter bool) []string {
 						breakdown += romanization2[string(syllable[4])]
 						syllable = syllable[5:]
 					}
-				} else if has("lɾmnŋwj", nth_rune(syllable, 3)) {
+				} else if hasAt("lɾmnŋwj", syllable, 3) {
 					// ts + other consonent
 					breakdown += romanization2[nth_rune(syllable, 3)]
 					syllable = syllable[4+len(nth_rune(syllable, 3)):]
@@ -1216,10 +1216,10 @@ func ReefMe(ipa string, inter bool) []string {
 					// ts without a cluster
 					syllable = syllable[4:]
 				}
-			} else if has("fs", nth_rune(syllable, 0)) {
+			} else if hasAt("fs", syllable, 0) {
 				//
 				breakdown += nth_rune(syllable, 0)
-				if has("ptk", nth_rune(syllable, 1)) {
+				if hasAt("ptk", syllable, 1) {
 					if nth_rune(syllable, 2) == "'" {
 						// f/s + ejective onset
 						breakdown += romanization2[syllable[1:3]]
@@ -1229,7 +1229,7 @@ func ReefMe(ipa string, inter bool) []string {
 						breakdown += romanization2[string(syllable[1])]
 						syllable = syllable[2:]
 					}
-				} else if has("lɾmnŋwj", nth_rune(syllable, 1)) {
+				} else if hasAt("lɾmnŋwj", syllable, 1) {
 					// f/s + other consonent
 					breakdown += romanization2[nth_rune(syllable, 1)]
 					syllable = syllable[1+len(nth_rune(syllable, 1)):]
@@ -1237,7 +1237,7 @@ func ReefMe(ipa string, inter bool) []string {
 					// f/s without a cluster
 					syllable = syllable[1:]
 				}
-			} else if has("ptk", nth_rune(syllable, 0)) {
+			} else if hasAt("ptk", syllable, 0) {
 				if nth_rune(syllable, 1) == "'" {
 					// ejective
 					breakdown += romanization2[syllable[0:2]]
@@ -1247,11 +1247,11 @@ func ReefMe(ipa string, inter bool) []string {
 					breakdown += romanization2[string(syllable[0])]
 					syllable = syllable[1:]
 				}
-			} else if has("ʔlɾhmnŋvwjzbdg", nth_rune(syllable, 0)) {
+			} else if hasAt("ʔlɾhmnŋvwjzbdg", syllable, 0) {
 				// other normal onset
 				breakdown += romanization2[nth_rune(syllable, 0)]
 				syllable = syllable[len(nth_rune(syllable, 0)):]
-			} else if has("ʃʒ", nth_rune(syllable, 0)) {
+			} else if hasAt("ʃʒ", syllable, 0) {
 				// one sound representd as a cluster
 				if nth_rune(syllable, 0) == "ʃ" {
 					breakdown += "sh"
@@ -1262,11 +1262,11 @@ func ReefMe(ipa string, inter bool) []string {
 			/*
 			 * Nucleus
 			 */
-			if len(syllable) > 1 && has("jw", nth_rune(syllable, 1)) {
+			if len(syllable) > 1 && hasAt("jw", syllable, 1) {
 				//diphthong
 				breakdown += romanization2[syllable[0:len(nth_rune(syllable, 0))+1]]
 				syllable = string([]rune(syllable)[2:])
-			} else if len(syllable) > 1 && has("lr", nth_rune(syllable, 0)) {
+			} else if len(syllable) > 1 && hasAt("lr", syllable, 0) {
 				//psuedovowel
 				breakdown += romanization2[syllable[0:3]]
 				continue // psuedovowels can't coda

--- a/fwew.go
+++ b/fwew.go
@@ -1040,11 +1040,11 @@ func dialectCrunch(query []string, guaranteedForest bool) []string {
 
 		nucleusCount := 0
 		// remove reef tìftangs
-		for _, b := range []string{"a", "ä", "e", "i", "ì", "o", "u", "ù", "ll", "rr"} {
+		for i, b := range []string{"a", "ä", "e", "i", "ì", "o", "u", "ù", "ll", "rr"} {
 			if strings.Contains(a, b) {
 				nucleusCount += strings.Count(a, b)
-				for _, c := range []string{"a", "ä", "e", "i", "ì", "o", "u", "ù", "ll", "rr"} {
-					if b != "ll" && c != "ll" && b != "rr" && c != "rr" {
+				for j, c := range []string{"a", "ä", "e", "i", "ì", "o", "u", "ù", "ll", "rr"} {
+					if i < 8 && j < 8 {
 						a = strings.ReplaceAll(a, b+"'"+c, b+c)
 					}
 				}

--- a/fwew.go
+++ b/fwew.go
@@ -168,8 +168,10 @@ func TranslateFromNaviHash(searchNaviWords string, checkFixes bool) (results [][
 	results = [][]Word{}
 
 	for i < len(allWords) {
-		// Skip empty words
-		if len(allWords[i]) == 0 {
+		// Skip empty words or ridiculously long words
+		// 50 was chosen because a quick and dirty program found the max
+		// Na'vi word length is 43 (before adding sì to the end)
+		if len(allWords[i]) == 0 || len([]rune(allWords[i])) > 50 {
 			i++
 			continue
 		}

--- a/fwew.go
+++ b/fwew.go
@@ -900,23 +900,27 @@ func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode strin
 	results = [][]Word{}
 	for i < len(allWords) {
 		// Search for Na'vi words
-		foundNavi := false
 		j, newWords, error2 := TranslateFromNaviHashHelper(i, allWords, checkFixes)
+
+		NaviIDs := []string{}
 		if error2 == nil {
 			for _, newWord := range newWords {
 				// Set up receptacle for words
 				results = append(results, []Word{})
 				results[len(results)-1] = append(results[len(results)-1], newWord...)
+				if len(newWord) > 1 {
+					NaviIDs = append(NaviIDs, newWord[1].ID)
+				}
 			}
-
-			results[len(results)-1][0].Navi = newWords[0][0].Navi
-
-			foundNavi = true
 		}
 
 		// Search for natural language words
 		natlangWords := []Word{}
 		for _, a := range TranslateToNaviHashHelper(allWords[i], langCode) {
+			// Do not duplicate if the Na'vi word is in the definition
+			if implContainsAny(NaviIDs, []string{a.ID}) {
+				continue
+			}
 			// We want them alphabetized with their fellow natlang words...
 			natlangWords = AppendAndAlphabetize(natlangWords, a)
 		}
@@ -924,9 +928,7 @@ func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode strin
 		// ...but not with the Na'vi words
 		results[len(results)-1] = append(results[len(results)-1], natlangWords...)
 
-		if !foundNavi {
-			results[len(results)-1][0].Navi = allWords[i]
-		}
+		results[len(results)-1][0].Navi = allWords[i]
 
 		i += j
 

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -688,6 +688,53 @@ var naviWords = []struct {
 			},
 		},
 	}, // start-attributed verb with removed tìftang in reef
+	{
+		name: "tsukruna",
+		args: args{
+			searchNaviText: "tsukruna",
+		},
+		want: []Word{
+			{
+				ID:   "1724",
+				Navi: "run",
+				Affixes: affix{
+					Suffix: []string{"a"},
+					Prefix: []string{"tsuk"},
+				},
+			},
+		},
+	}, // findable
+	{
+		name: "atsukrun",
+		args: args{
+			searchNaviText: "atsukrun",
+		},
+		want: []Word{
+			{
+				ID:   "1724",
+				Navi: "run",
+				Affixes: affix{
+					Prefix: []string{"a", "tsuk"},
+				},
+			},
+		},
+	}, // findable
+	{
+		name: "tìngusä'än",
+		args: args{
+			searchNaviText: "tìngusä'än",
+		},
+		want: []Word{
+			{
+				ID:   "9632",
+				Navi: "ngä'än",
+				Affixes: affix{
+					Prefix: []string{"tì"},
+					Infix:  []string{"us"},
+				},
+			},
+		},
+	}, // suffering
 }
 var englishWords = []struct {
 	name string

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -374,11 +374,6 @@ var naviWords = []struct {
 		},
 		want: []Word{
 			{
-				ID:      "6156",
-				Navi:    "tìtusaron",
-				Affixes: affix{},
-			},
-			{
 				ID:   "2004",
 				Navi: "taron",
 				Affixes: affix{

--- a/name_gen.go
+++ b/name_gen.go
@@ -110,7 +110,7 @@ func FullNames(ending string, name_count int, dialect int, syllable_count [3]int
 		}
 
 		// In reef dialect, glottal stops between nonidentical vowels are dropped
-		if dialect == 2 && has("aäeìouù", get_last_rune(output, 1)) {
+		if dialect == 2 && hasAt("aäeìouù", output, 1) {
 			ending2 = ending2[1:]
 		}
 
@@ -247,8 +247,7 @@ func NameAlu(name_count int, dialect int, syllable_count int, noun_mode int, adj
 				} else {
 					adj = convertDialect(adj_word, dialect)
 					adjSplit := strings.Split(adj, " ")
-					adj_rune := []rune(adjSplit[0])
-					if has("aeìiä", string(adj_rune[len(adj_rune)-1])) {
+					if hasAt("aeìiä", adjSplit[0], -1) {
 						adjSplit[0] = adjSplit[0] + "yä"
 					} else {
 						adjSplit[0] = adjSplit[0] + "ä"

--- a/name_gen_core.go
+++ b/name_gen_core.go
@@ -104,18 +104,18 @@ var max_nucleus = 0
 var max_coda = 0
 
 /* Helper function to find the start of a string */
-func first_rune(word string) (letter string) {
+func first_rune(word string) (letter rune) {
 	r := []rune(word)
-	return string(r[:1])
+	return r[0]
 }
 
 /* Get the nth to last letter of a string */
-func get_last_rune(word string, n int) (letter string) {
+func get_last_rune(word string, n int) (letter rune) {
 	r := []rune(word)
 	if n > len(r) {
 		n = len(r)
 	}
-	return string(r[len(r)-n : len(r)-n+1])
+	return r[len(r)-n]
 }
 
 /* Take n letters off the end of a string */
@@ -223,12 +223,12 @@ func rand_if_zero(n int) (x int) {
 }
 
 /* Is it a vowel? (for when the psuedovowel bool won't work) */
-func is_vowel(letter string) (found bool) {
+func is_vowel(letter rune) (found bool) {
 	// Also arranged from most to least common (not accounting for diphthongs)
-	vowels := []string{"a", "e", "u", "ì", "o", "i", "ä", "ù"}
+	vowels := []rune{'a', 'e', 'u', 'ì', 'o', 'i', 'ä', 'ù'}
 	// Linear search
-	for i := 0; i < 8; i++ {
-		if letter == vowels[i] {
+	for _, a := range vowels {
+		if letter == a {
 			return true
 		}
 	}
@@ -308,15 +308,15 @@ func one_word_verb(verbList []Word) (words Word) {
 }
 
 /* Helper function: turn ejectives into voiced plosives for reef */
-func reef_plosives(letter string) (voiced string) {
-	if letter == "p" {
-		return "b"
-	} else if letter == "t" {
-		return "d"
-	} else if letter == "k" {
-		return "g"
+func reef_plosives(letter rune) (voiced rune) {
+	if letter == 'p' {
+		return 'b'
+	} else if letter == 't' {
+		return 'd'
+	} else if letter == 'k' {
+		return 'g'
 	}
-	return "" // How we know if it's an error
+	return '' // How we know if it's an error
 }
 
 /* Helper function: Replace an ejective with a voiced plosive. */
@@ -324,15 +324,15 @@ func reef_ejective(name string) (reefy_name string) {
 	onset_new := ""
 	last_third := get_last_rune(name, 3)
 
-	if last_third == "x" { // Adjacent ejectives become adjacent voiced plosives, too
-		onset_new += reef_plosives(get_last_rune(name, 4))
-	} else if last_third == "n" && get_last_rune(name, 2) == "k" {
+	if last_third == 'x' { // Adjacent ejectives become adjacent voiced plosives, too
+		onset_new += string(reef_plosives(get_last_rune(name, 4)))
+	} else if last_third == 'n' && get_last_rune(name, 2) == 'k' {
 		onset_new += "-" // disambiguate on-gi vs o-ngi
 	}
 
-	onset_new += reef_plosives(get_last_rune(name, 2))
+	onset_new += string(reef_plosives(get_last_rune(name, 2)))
 
-	if last_third == "x" {
+	if last_third == 'x' {
 		return shave_rune(name, 4) + onset_new
 	}
 
@@ -404,7 +404,7 @@ func single_name_gen(syllable_count int, dialect int) (name string) {
 			psuedovowel = true
 			// Disallow onsets from imitating the psuedovowel
 			if onsetlength > 0 {
-				if get_last_rune(onset, 1) == "l" || get_last_rune(onset, 1) == "r" {
+				if get_last_rune(onset, 1) == 'l' || get_last_rune(onset, 1) == 'r' {
 					onset = "'"
 				}
 				// If no onset, disallow the previous coda from imitating the psuedovowel
@@ -469,18 +469,18 @@ func single_name_gen(syllable_count int, dialect int) (name string) {
 
 		// reef dialect stuff
 		if dialect == 2 && namelength > 1 { // In reef dialect,
-			if get_last_rune(name, 1) == "x" { // if there's an ejective in the onset
+			if get_last_rune(name, 1) == 'x' { // if there's an ejective in the onset
 				if namelength > 2 {
 					// that's not in a cluster,
 					last_rune := get_last_rune(name, 3)
-					if !(last_rune == "s" || last_rune == "f") {
+					if !(last_rune == 's' || last_rune == 'f') {
 						// it becomes a voiced plosive
 						name = reef_ejective(name)
 					}
 				} else {
 					name = reef_ejective(name)
 				}
-			} else if !psuedovowel && get_last_rune(name, 1) == "'" && get_last_rune(name, 2) != first_rune(nucleus) {
+			} else if !psuedovowel && get_last_rune(name, 1) == '\'' && get_last_rune(name, 2) != first_rune(nucleus) {
 				// 'a'aw is optionally 'aaw (the generator leaves it in)
 				if is_vowel(get_last_rune(name, 2)) { // Does kaw'it become kawit in reef?
 					name = shave_rune(name, 1)

--- a/name_gen_core.go
+++ b/name_gen_core.go
@@ -150,9 +150,11 @@ func quickReef(input string) string {
 	temp := ""
 	runes := []rune(output)
 
+	vowels := "aäeiìouù"
+
 	for i, a := range runes {
 		if i != 0 && i != len(runes)-1 && a == rune('\'') {
-			if is_vowel(string(runes[i+1])) && is_vowel(string(runes[i-1])) {
+			if hasAt(vowels, output, i+1) && hasAt(vowels, output, i-1) {
 				if runes[i+1] != runes[i-1] {
 					continue
 				}

--- a/name_gen_core.go
+++ b/name_gen_core.go
@@ -514,28 +514,50 @@ func fast_random(wordList []Word) (results Word) {
 	return wordList[rand.Intn(dictLength)]
 }
 
-func nth_rune(word string, n int) (output string) {
-	r := []rune(word)
-	if n < 0 { // negative index
-		n = len(r) + n
+// What is the nth rune of word?
+func nth_rune(word string, n int) string {
+	i := 0
+	for _, r := range word {
+		if i == n {
+			return string(r)
+		}
+		i += 1
 	}
-	if n >= len(r) {
-		return ""
-	}
-	return string(r[n])
+
+	return ""
 }
 
-func has(word string, character string) (output bool) {
+func has(word string, character rune) (output bool) {
 	r := []rune(word)
-	if len(character) == 0 {
-		return false
-	}
-	c := []rune(character)[0]
+
 	for i := 0; i < len(r); i++ {
-		if c == r[i] {
+		if character == r[i] {
 			return true
 		}
 	}
+	return false
+}
+
+// Does ipa contain any character from word as its nth letter?
+func hasAt(word string, ipa string, n int) (output bool) {
+	// negative index
+	if n < 0 {
+		n = len([]rune(ipa)) + n
+	}
+
+	i := 0
+	for _, s := range ipa {
+		if i == n {
+			for _, r := range word {
+				if r == s {
+					return true
+				}
+			}
+			break // save a few compute cycles
+		}
+		i += 1
+	}
+
 	return false
 }
 
@@ -657,7 +679,7 @@ func PhonemeDistros() {
 				if len(syllable) >= 4 && syllable[0:4] == "t͡s" {
 					onset_if_cluster[0] = "ts"
 					//tsp
-					if has("ptk", nth_rune(syllable, 3)) {
+					if hasAt("ptk", syllable, 3) {
 						if nth_rune(syllable, 4) == "'" {
 							// ts + ejective onset
 							cluster_map["ts"][romanization[syllable[4:6]]] = cluster_map["ts"][romanization[syllable[4:6]]] + 1
@@ -671,7 +693,7 @@ func PhonemeDistros() {
 							//roman_syllable += "ts" + romanization[string(syllable[4])]
 							syllable = syllable[5:]
 						}
-					} else if has("lɾmnŋwj", nth_rune(syllable, 3)) {
+					} else if hasAt("lɾmnŋwj", syllable, 3) {
 						// ts + other consonent
 						cluster_map["ts"][romanization[nth_rune(syllable, 3)]] = cluster_map["ts"][romanization[nth_rune(syllable, 3)]] + 1
 						onset_if_cluster[1] = romanization[nth_rune(syllable, 3)]
@@ -683,10 +705,10 @@ func PhonemeDistros() {
 						//roman_syllable += "ts"
 						syllable = syllable[4:]
 					}
-				} else if has("fs", nth_rune(syllable, 0)) {
+				} else if hasAt("fs", syllable, 0) {
 					//
 					onset_if_cluster[0] = string(syllable[0])
-					if has("ptk", nth_rune(syllable, 1)) {
+					if hasAt("ptk", syllable, 1) {
 						if nth_rune(syllable, 2) == "'" {
 							// f/s + ejective onset
 							cluster_map[string(syllable[0])][romanization[syllable[1:3]]] = cluster_map[string(syllable[0])][romanization[syllable[1:3]]] + 1
@@ -700,7 +722,7 @@ func PhonemeDistros() {
 							//roman_syllable += string(syllable[0]) + romanization[string(syllable[1])]
 							syllable = syllable[2:]
 						}
-					} else if has("lɾmnŋwj", nth_rune(syllable, 1)) {
+					} else if hasAt("lɾmnŋwj", syllable, 1) {
 						// f/s + other consonent
 						cluster_map[string(syllable[0])][romanization[nth_rune(syllable, 1)]] = cluster_map[string(syllable[0])][romanization[nth_rune(syllable, 1)]] + 1
 						onset_if_cluster[1] = romanization[nth_rune(syllable, 1)]
@@ -712,7 +734,7 @@ func PhonemeDistros() {
 						//roman_syllable += string(syllable[0])
 						syllable = syllable[1:]
 					}
-				} else if has("ptk", nth_rune(syllable, 0)) {
+				} else if hasAt("ptk", syllable, 0) {
 					if nth_rune(syllable, 1) == "'" {
 						// ejective
 						onset_map[romanization[syllable[0:2]]] = onset_map[romanization[syllable[0:2]]] + 1
@@ -724,12 +746,12 @@ func PhonemeDistros() {
 						//roman_syllable += romanization[string(syllable[0])]
 						syllable = syllable[1:]
 					}
-				} else if has("ʔlɾhmnŋvwjzbdg", nth_rune(syllable, 0)) {
+				} else if hasAt("ʔlɾhmnŋvwjzbdg", syllable, 0) {
 					// other normal onset
 					onset_map[romanization[nth_rune(syllable, 0)]] = onset_map[romanization[nth_rune(syllable, 0)]] + 1
 					//roman_syllable += romanization[nth_rune(syllable, 0)]
 					syllable = syllable[len(nth_rune(syllable, 0)):]
-				} else if has("ʃʒ", nth_rune(syllable, 0)) {
+				} else if hasAt("ʃʒ", syllable, 0) {
 					// one sound representd as a cluster
 					if nth_rune(syllable, 0) == "ʃ" {
 						cluster_map["s"]["y"] = cluster_map["s"]["y"] + 1
@@ -766,12 +788,12 @@ func PhonemeDistros() {
 				/*
 				 * Nucleus
 				 */
-				if len(syllable) > 1 && has("jw", nth_rune(syllable, 1)) {
+				if len(syllable) > 1 && hasAt("jw", syllable, 1) {
 					//diphthong
 					nucleus_map[romanization[syllable[0:len(nth_rune(syllable, 0))+1]]] = nucleus_map[romanization[syllable[0:len(nth_rune(syllable, 0))+1]]] + 1
 					//roman_syllable += romanization[syllable[0:len(nth_rune(syllable, 0))+1]]
 					syllable = string([]rune(syllable)[2:])
-				} else if len(syllable) > 1 && has("lr", nth_rune(syllable, 0)) {
+				} else if len(syllable) > 1 && hasAt("lr", syllable, 0) {
 					nucleus_map[romanization[syllable[0:3]]] = nucleus_map[romanization[syllable[0:3]]] + 1
 					//roman_syllable += romanization[syllable[0:3]]
 					continue


### PR DESCRIPTION
For example, the English definition of the Na'vi word Kinglor is "Kinglor", which makes "Kinglor" appear twice in bidirectional search.  This update ensures no duplicates appear in bidirectional search.

Additional test cases as well such as _tìngusä'än_ (suffering (gerund))

Limited searchable Na'vi word lengths to 50 runes to make it harder for users to making Fwew hang

Changed a bunch of methods to minimize string/rune conversions for maybe an unnoticeable increase in speed or a slight decrease in RAM used

Capitalized things in affixes_hash.go to allow [litxap](https://github.com/gissleh/litxap/pull/2) to access them