### PR TITLE
Immunized from "ololol" DoS thing

### DIFF
--- a/affixes.go
+++ b/affixes.go
@@ -801,13 +801,13 @@ func GetShortLenitionTable() [][2]string {
 var thatTable = [9][5]string{
 	{"Case", "Noun", "   Clause Wrapper   ", "", ""},
 	{" ", " ", "Prox.", "Dist.", "Answer "},
-	{"====", "=====", "=====", "======", "======="},
-	{"Sub.", "tsaw", "fwa", "tsawa", "teynga "},
-	{"Agt.", "tsal", "fula", "tsala", "teyngla"},
-	{"Pat.", "tsat", "futa", "tsata", "teyngta"},
-	{"Gen.", "tseyä", "N/A", "N/A", ""},
-	{"Dat.", "tsar", "fura", "tsara", ""},
-	{"Top.", "tsari", "furia", "tsaria", ""},
+	{"====", "=====", "=====", "======", "========"},
+	{"Sub.", "tsaw", "fwa", "tsawa", "teynga  "},
+	{"Agt.", "tsal", "fula", "tsala", "teyngla "},
+	{"Pat.", "tsat", "futa", "tsata", "teyngta "},
+	{"Gen.", "tseyä", "N/A", "N/A", "teyngä  "},
+	{"Dat.", "tsar", "fura", "tsara", "teyngra "},
+	{"Top.", "tsari", "furia", "tsaria", "teyngria"},
 }
 
 func GetThatTable() [][5]string {

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -1052,7 +1052,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						firstInfixes := ""
 
 						for _, newInfix := range candidate.Infixes {
-							if _, ok := prefirstMap[newInfix] {
+							if _, ok := prefirstMap[newInfix]; ok {
 								firstInfixes += newInfix
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<0>", firstInfixes)
 								if newInfix == "epeyk" || newInfix == "äpeyk" {
@@ -1076,7 +1076,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						// first position infixes
 						firstInfixes = ""
 						for _, newInfix := range candidate.Infixes {
-							if _, ok := firstMap[newInfix] {
+							if _, ok := firstMap[newInfix]; ok {
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<1>", newInfix)
 								firstInfixes = newInfix
 								if newInfix == "ol" {
@@ -1094,7 +1094,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 							if newInfix == "eng" {
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<2>", "äng")
 								break
-							} else if _, ok := secondMap[newInfix] {
+							} else if _, ok := secondMap[newInfix]; ok {
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<2>", newInfix)
 								break
 							}

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -631,9 +631,6 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 							deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, []string{}, "", "yä")
 						}
 					}
-				} else {
-					newCandidate.Word = strings.TrimSuffix(newString, oldSuffix)
-					deconjugateHelper(newCandidate, newPrefixCheck, 2, unlenite, []string{}, "", oldSuffix)
 				}
 			}
 		}

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -82,14 +82,14 @@ var verbPrefixes = []string{"tsuk", "ketsuk"}
 
 var adposuffixes = []string{
 	// adpositions that can be mistaken for case endings
-	"pxel",                //"agentive"
-	"mungwrr",             //"dative"
-	"kxamlä", "ìlä", "wä", //"genitive"
+	"pxel",                                       //"agentive"
+	"mungwrr",                                    //"dative"
+	"kxamlä", "ìlä", "wä", "kxamle", "ìle", "we", //"genitive"
 	"teri", //"topical"
 	// Case endings
 	"ìl", "l", "it", "ti", "t", "ur", "ru", "r", "yä", "ä", "e", "ye", "ìri", "ri",
 	// Sorted alphabetically by their reverse forms
-	"nemfa", "rofa", "ka", "fa", "na", "ta", "ya", //-a
+	"ftumfa", "nemfa", "rofa", "ka", "fa", "na", "ta", "ya", //-a
 	"lisre", "pxisre", "sre", "luke", "ne", //-e
 	"fpi",          //-i
 	"mì",           //-ì
@@ -136,6 +136,15 @@ var firstMap = map[string]bool{"ay": true, "asy": true, "aly": true, "ary": true
 	"iv": true, "ilv": true, "irv": true, "imv": true, "us": true, "awn": true}
 var secondMap = map[string]bool{"ei": true, "eiy": true, "äng": true, "eng": true, "uy": true, "ats": true}
 
+var unreefFixes = map[string]string{
+	"eng": "äng",
+	"ep":  "äp",
+	"ye":  "yä",
+	"e":   "ä",
+	"we":  "wä",
+	"ìle": "ìlä",
+}
+
 var weirdNounSuffixes = map[string]string{
 	// For "tsa" with case endings
 	// Canonized in:
@@ -172,16 +181,8 @@ func isDuplicate(input ConjugationCandidate) bool {
 }
 
 func isDuplicateFix(fixes []string, fix string) (newFixes []string) {
-	if fix == "eng" {
-		fix = "äng"
-	} else if fix == "ep" {
-		fix = "äp"
-	} else if fix == "epeyk" {
-		fix = "äpeyk"
-	} else if fix == "ye" {
-		fix = "yä"
-	} else if fix == "e" {
-		fix = "ä"
+	if newfix, ok := unreefFixes[fix]; ok {
+		fix = newfix
 	}
 	for _, a := range fixes {
 		if fix == a {

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -1052,7 +1052,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						firstInfixes := ""
 
 						for _, newInfix := range candidate.Infixes {
-							if implContainsAny(prefirst, []string{newInfix}) {
+							if _, ok := prefirstMap[newInfix] {
 								firstInfixes += newInfix
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<0>", firstInfixes)
 								if newInfix == "epeyk" || newInfix == "äpeyk" {
@@ -1076,7 +1076,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 						// first position infixes
 						firstInfixes = ""
 						for _, newInfix := range candidate.Infixes {
-							if implContainsAny(first, []string{newInfix}) {
+							if _, ok := firstMap[newInfix] {
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<1>", newInfix)
 								firstInfixes = newInfix
 								if newInfix == "ol" {
@@ -1094,7 +1094,7 @@ func TestDeconjugations(searchNaviWord string) (results []Word) {
 							if newInfix == "eng" {
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<2>", "äng")
 								break
-							} else if implContainsAny(second, []string{newInfix}) {
+							} else if _, ok := secondMap[newInfix] {
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<2>", newInfix)
 								break
 							}

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -82,24 +82,24 @@ var verbPrefixes = []string{"tsuk", "ketsuk"}
 
 var adposuffixes = []string{
 	// adpositions that can be mistaken for case endings
-	"pxel",                                       //"agentive"
-	"mungwrr",                                    //"dative"
-	"kxamlä", "ìlä", "wä", "kxamle", "ìle", "we", //"genitive"
+	"pxel",                                                     //"agentive"
+	"mungwrr",                                                  //"dative"
+	"kxamlä", "ìlä", "wä", "nuä", "kxamle", "ìle", "we", "nue", //"genitive"
 	"teri", //"topical"
 	// Case endings
 	"ìl", "l", "it", "ti", "t", "ur", "ru", "r", "yä", "ä", "e", "ye", "ìri", "ri",
 	// Sorted alphabetically by their reverse forms
-	"ftumfa", "nemfa", "rofa", "ka", "fa", "na", "ta", "ya", //-a
+	"ftumfa", "nemfa", "rofa", "ka", "fa", "na", "ta", "ya", "yoa", "krrka", "ftuopa", //-a
 	"lisre", "pxisre", "sre", "luke", "ne", //-e
 	"fpi",          //-i
 	"mì",           //-ì
 	"lok",          //-k
 	"mìkam", "kam", //-m
-	"ken", "sìn", //-n
-	"äo", "eo", "io", "uo", "ro", "to", //-o
+	"ken", "sìn", "talun", //-n
+	"äo", "eo", "io", "uo", "ro", "to", "sko", //-o
 	"tafkip", "takip", "fkip", "kip", //-p
 	"ftu", "hu", //-u
-	"pximaw", "maw", "pxaw", "few", //-w
+	"pximaw", "maw", "pxaw", "few", "raw", //-w
 	"vay", "kay", //-y
 }
 
@@ -137,12 +137,13 @@ var firstMap = map[string]bool{"ay": true, "asy": true, "aly": true, "ary": true
 var secondMap = map[string]bool{"ei": true, "eiy": true, "äng": true, "eng": true, "uy": true, "ats": true}
 
 var unreefFixes = map[string]string{
-	"eng": "äng",
-	"ep":  "äp",
-	"ye":  "yä",
-	"e":   "ä",
-	"we":  "wä",
-	"ìle": "ìlä",
+	"eng":    "äng",
+	"ep":     "äp",
+	"ye":     "yä",
+	"e":      "ä",
+	"we":     "wä",
+	"ìle":    "ìlä",
+	"nue":    "nuä",
 	"kxamle": "kxamlä",
 }
 

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -232,18 +232,15 @@ func implContainsAny(sl []string, names []string) bool {
 func verifyInfix(existing []string, new string) (bool, []string) {
 	if _, ok := prefirstMap[new]; ok {
 		if existing[0] == "" {
-			existing[0] = new
-			return true, existing
+			return true, []string{new, existing[1], existing[2]}
 		}
 	} else if _, ok := firstMap[new]; ok {
 		if existing[1] == "" {
-			existing[1] = new
-			return true, existing
+			return true, []string{existing[0], new, existing[2]}
 		}
 	} else if _, ok := secondMap[new]; ok {
 		if existing[2] == "" {
-			existing[2] = new
-			return true, existing
+			return true, []string{existing[0], existing[1], new}
 		}
 	}
 
@@ -765,7 +762,7 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			newCandidate := candidateDupe(input)
 			newCandidate.Word = strings.TrimSuffix(input.Word, "si") + " si"
 			newCandidate.InsistPOS = "v."
-			deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, []string{"", "", ""}, "", "")
+			deconjugateHelper(newCandidate, newPrefixCheck, suffixCheck, unlenite, infix, "", "")
 		} else { // If there is a "si", we don't need to check for infixes
 			// Check for infixes
 			runes := []rune(input.Word)

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -147,6 +147,7 @@ var weirdNounSuffixes = map[string]string{
 	"päts":         "pätsì",
 	"post":         "postì",
 	"losäntsyeles": "losäntsyelesì",
+	"york":         "yorkì", // For a program called Litxap
 }
 
 func isDuplicate(input ConjugationCandidate) bool {

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -401,9 +401,9 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			newCandidate.Word = input.Word[1:]
 			newCandidate.Prefixes = isDuplicateFix(newCandidate.Prefixes, "a")
 			newCandidate.InsistPOS = "adj."
-			deconjugateHelper(newCandidate, 1, suffixCheck, -1, []string{"", "", ""}, "a", "")
-			newCandidate.InsistPOS = "v."
 			deconjugateHelper(newCandidate, 1, suffixCheck, -1, []string{}, "a", "")
+			newCandidate.InsistPOS = "v."
+			deconjugateHelper(newCandidate, 1, suffixCheck, -1, []string{"", "", ""}, "a", "")
 		} else if strings.HasPrefix(input.Word, "nì") {
 			newCandidate := candidateDupe(input)
 			newCandidate.Word = strings.TrimPrefix(input.Word, "nì")
@@ -661,9 +661,9 @@ func deconjugateHelper(input ConjugationCandidate, prefixCheck int, suffixCheck 
 			newCandidate.Word = newString
 			newCandidate.InsistPOS = "adj."
 			newCandidate.Suffixes = isDuplicateFix(newCandidate.Suffixes, "a")
-			deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, []string{}, "", "a")
+			deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, []string{"", "", ""}, "", "a")
 			newCandidate.InsistPOS = "v."
-			deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, []string{}, "", "a")
+			deconjugateHelper(newCandidate, newPrefixCheck, 4, unlenite, []string{"", "", ""}, "", "a")
 		}
 
 		fallthrough

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -140,7 +140,8 @@ var weirdNounSuffixes = map[string]string{
 	// For "tsa" with case endings
 	// Canonized in:
 	// https://naviteri.org/2011/08/new-vocabulary-clothing/comment-page-1/#comment-912
-	"tsa": "tsaw",
+	"tsa":   "tsaw",
+	"teyng": "tì'eyng",
 	// The a re-appears when case endings are added (it uses a instead of ì)
 	"oenga": "oeng",
 	// Foreign nouns

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -143,6 +143,7 @@ var unreefFixes = map[string]string{
 	"e":   "ä",
 	"we":  "wä",
 	"ìle": "ìlä",
+	"kxamle": "kxamlä",
 }
 
 var weirdNounSuffixes = map[string]string{

--- a/cache.go
+++ b/cache.go
@@ -118,7 +118,7 @@ func FindDictionaryFile() string {
 }
 
 func AlphabetizeHelper(a string, b string) bool {
-	aCompacted := []rune(strings.ReplaceAll(strings.ToLower(a), "-", ""))
+	aCompacted := []rune(strings.ReplaceAll(compress(strings.ToLower(a)), "-", ""))
 
 	// Start in the middle
 	bCompacted := []rune(strings.ReplaceAll(compress(strings.ToLower(b)), "-", ""))

--- a/fwew.go
+++ b/fwew.go
@@ -325,7 +325,7 @@ func TranslateFromNaviHashHelper(start int, allWords []string, checkFixes bool) 
 
 	// If one searches kivä, make sure kive doesn't show up
 	for _, a := range results[len(results)-1] {
-		if containsUmlaut[i] && !strings.Contains(a.Navi, "ä") {
+		if containsUmlaut[i] && !strings.Contains(strings.ToLower(a.Navi), "ä") {
 			continue // ä can unstress to e, but not the other way around
 		}
 		tempResults = append(tempResults, a)

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -742,6 +742,21 @@ var naviWords = []struct {
 			},
 		},
 	}, // Los Angeles
+	{
+		name: "teyngteri",
+		args: args{
+			searchNaviText: "teyngteri",
+		},
+		want: []Word{
+			{
+				ID:   "2136",
+				Navi: "tì'eyng",
+				Affixes: affix{
+					Suffix: []string{"teri"},
+				},
+			},
+		},
+	}, // About the answer
 }
 var englishWords = []struct {
 	name string

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -949,6 +949,28 @@ func TestTranslateFromNaviCached(t *testing.T) {
 		t.Errorf("TranslateFromNaviCached() Failed to CacheDictHash2")
 	}
 
+	for _, a := range adposuffixes {
+		word := "tsun" + a
+
+		if newfix, ok := unreefFixes[a]; ok {
+			a = newfix
+		}
+
+		affixes := affix{Suffix: []string{a}}
+		wordWord := Word{Navi: "tsun", ID: "13353", Affixes: affixes}
+		want := []Word{wordWord}
+		t.Run(word, func(t *testing.T) {
+			got, err := TranslateFromNaviHash(word, true)
+			if err == nil && word == "" && got != nil {
+				t.Errorf("TranslateFromNaviCached() got = %v, want %v", got, want)
+			} else if err == nil && len(want) == 0 && len(got) > 0 {
+				t.Errorf("TranslateFromNaviCached() got = %v, want %v", got, want)
+			} else if err != nil || len(want) > 0 && len(got) > 0 && !wordSimpleEqual(got[0][1:], want) {
+				t.Errorf("TranslateFromNaviCached() = %v, want %v", got[0][1:], want)
+			}
+		})
+	}
+
 	for _, tt := range naviWords {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := TranslateFromNaviHash(tt.args.searchNaviText, true)

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -730,6 +730,18 @@ var naviWords = []struct {
 			},
 		},
 	}, // suffering
+	{
+		name: "LosÄntsyelesì",
+		args: args{
+			searchNaviText: "LosÄntsyelesì",
+		},
+		want: []Word{
+			{
+				ID:   "10152",
+				Navi: "LosÄntsyelesì",
+			},
+		},
+	}, // Los Angeles
 }
 var englishWords = []struct {
 	name string

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -757,6 +757,51 @@ var naviWords = []struct {
 			},
 		},
 	}, // About the answer
+	{
+		name: "yaìlä",
+		args: args{
+			searchNaviText: "yaìlä",
+		},
+		want: []Word{
+			{
+				ID:   "2724",
+				Navi: "ya",
+				Affixes: affix{
+					Suffix: []string{"ìlä"},
+				},
+			},
+		},
+	}, // Through the air
+	{
+		name: "yawä",
+		args: args{
+			searchNaviText: "yawä",
+		},
+		want: []Word{
+			{
+				ID:   "2724",
+				Navi: "ya",
+				Affixes: affix{
+					Suffix: []string{"wä"},
+				},
+			},
+		},
+	}, // Against the air
+	{
+		name: "yaftumfa",
+		args: args{
+			searchNaviText: "yaftumfa",
+		},
+		want: []Word{
+			{
+				ID:   "2724",
+				Navi: "ya",
+				Affixes: affix{
+					Suffix: []string{"ftumfa"},
+				},
+			},
+		},
+	}, // Out of the air
 }
 var englishWords = []struct {
 	name string


### PR DESCRIPTION
Avoided it through efficiency alone, not searching for substrings to reject

Fixed bugs:
- Capital Ä interfered with the reef dialect flexibilities (and made LosÄntsyelesì searchable from the Na'vi word)
- A word with the same case ending or adposition after it twice would be a false positive
- Wä, kxamlä, ìlä and ftumfa are recognized suffixes now