### PR TITLE
Advanced search flexibility

### DIFF
--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -907,7 +907,7 @@ func Deconjugate(input string, strict bool) []ConjugationCandidate {
 func TestDeconjugations(dict *map[string][]Word, searchNaviWord string, strict bool) (results []Word) {
 	conjugations := Deconjugate(searchNaviWord, strict)
 
-	allAConfigs := []string{searchNaviWord}
+	allAConfigs := []string{strings.ReplaceAll(searchNaviWord, "ù", "u")}
 
 	buffer := strings.Builder{}
 

--- a/affixes_hash.go
+++ b/affixes_hash.go
@@ -117,7 +117,7 @@ var stemSuffixes = []string{"tsyìp", "fkeyk"}
 var verbSuffixes = []string{"tswo", "yu"}
 
 var infixes = map[rune][]string{
-	rune('a'): {"ay", "asy", "aly", "ary", "am", "alm", "arm", "ats", "awn"},
+	rune('a'): {"ay", "asy", "aly", "ary", "am", "alm", "arm", "ats", "awn", "ap", "ang"},
 	rune('ä'): {"äng", "äpeyk", "äp"},
 	rune('e'): {"epeyk", "ep", "eng", "er", "ei", "eiy", "eyk"},
 	rune('i'): {"iv", "ilv", "irv", "imv", "iyev"},
@@ -136,7 +136,7 @@ var firstMap = map[string]bool{"ay": true, "asy": true, "aly": true, "ary": true
 	"ìly": true, "ìry": true, "ol": true, "er": true, "ìm": true, "ìlm": true,
 	"ìrm": true, "am": true, "alm": true, "arm": true, "ìyev": true, "iyev": true,
 	"iv": true, "ilv": true, "irv": true, "imv": true, "us": true, "awn": true}
-var secondMap = map[string]bool{"ei": true, "eiy": true, "äng": true, "uy": true, "ats": true}
+var secondMap = map[string]bool{"ei": true, "eiy": true, "äng": true, "uy": true, "ats": true, "ap": true, "ang": true}
 
 var unreefFixes = map[string]string{
 	"eng":    "äng",
@@ -156,6 +156,8 @@ var unreefFixes = map[string]string{
 	"sin":   "sìn",
 	"il":    "ìl",
 	"iri":   "ìri",
+	"ap":    "äp",
+	"ang":   "äng",
 }
 
 var weirdNounSuffixes = map[string]string{
@@ -1236,7 +1238,7 @@ func TestDeconjugations(dict *map[string][]Word, searchNaviWord string, strict b
 
 						// second position infixes
 						for _, newInfix := range candidate.Infixes {
-							if !strict && newInfix == "eng" {
+							if !strict && (newInfix == "eng" || newInfix == "ang") {
 								rebuiltVerb = strings.ReplaceAll(rebuiltVerb, "<2>", "äng")
 								break
 							} else if _, ok := secondMap[newInfix]; ok {

--- a/cache.go
+++ b/cache.go
@@ -22,6 +22,7 @@ var dictHashStrict map[string][]Word
 var dictionaryCached bool
 var dictHashCached bool
 var dictHash2 MetaDict
+var dictHash2Parenthesis MetaDict
 var dictHash2Cached bool
 var homonyms string
 var oddballs string
@@ -614,18 +615,22 @@ func CacheDictHashOrig(mysql bool) error {
 }
 
 // Turn a definition into its searchable terms
-func SearchTerms(input string) []string {
+func SearchTerms(input string, excludeParen bool) []string {
 	badChars := `~@#$%^&*()[]{}<>_/.,;:!?|+\"„“”«»`
+
+	input = strings.ReplaceAll(input, "(", " (")
 
 	// remove anything in parenthesis to avoid clogging search results
 	tempString := ""
 	parenthesis := false
 	for _, c := range input {
-		if c == '(' {
-			parenthesis = true
-		} else if c == ')' {
-			parenthesis = false
-			continue
+		if excludeParen {
+			if c == '(' {
+				parenthesis = true
+			} else if c == ')' {
+				parenthesis = false
+				continue
+			}
 		}
 
 		if !parenthesis {
@@ -645,12 +650,13 @@ func SearchTerms(input string) []string {
 
 	// find everything lowercase
 	input = strings.ToLower(input)
+
 	return strings.Split(input, " ")
 }
 
 // Helper function for CacheDictHash2
-func AssignWord(wordmap map[string][]string, natlangWords string, naviWord string) (result map[string][]string) {
-	newWords := SearchTerms(natlangWords)
+func AssignWord(wordmap map[string][]string, natlangWords string, naviWord string, excludeParen bool) (result map[string][]string) {
+	newWords := SearchTerms(natlangWords, excludeParen)
 
 	for i := 0; i < len(newWords); i++ {
 		duplicate := false
@@ -698,6 +704,21 @@ func CacheDictHash2Orig(mysql bool) error {
 		dictHash2.SV = make(map[string][]string)
 		dictHash2.TR = make(map[string][]string)
 		dictHash2.UK = make(map[string][]string)
+
+		dictHash2Parenthesis.EN = make(map[string][]string)
+		dictHash2Parenthesis.DE = make(map[string][]string)
+		dictHash2Parenthesis.ES = make(map[string][]string)
+		dictHash2Parenthesis.ET = make(map[string][]string)
+		dictHash2Parenthesis.FR = make(map[string][]string)
+		dictHash2Parenthesis.HU = make(map[string][]string)
+		dictHash2Parenthesis.KO = make(map[string][]string)
+		dictHash2Parenthesis.NL = make(map[string][]string)
+		dictHash2Parenthesis.PL = make(map[string][]string)
+		dictHash2Parenthesis.PT = make(map[string][]string)
+		dictHash2Parenthesis.RU = make(map[string][]string)
+		dictHash2Parenthesis.SV = make(map[string][]string)
+		dictHash2Parenthesis.TR = make(map[string][]string)
+		dictHash2Parenthesis.UK = make(map[string][]string)
 	}
 
 	// Set up the whole thing
@@ -706,83 +727,88 @@ func CacheDictHash2Orig(mysql bool) error {
 		standardizedWord := strings.ToLower(word.Navi)
 		standardizedWord = strings.ReplaceAll(standardizedWord, "+", "")
 
-		standardizedWordArray := dialectCrunch(strings.Split(standardizedWord, " "), true)
-		standardizedWord = ""
-		for i, b := range standardizedWordArray {
-			if i != 0 {
-				standardizedWord += " "
-			}
-			standardizedWord += b
-		}
-
 		// English
 		if !NullDef(word.EN) {
-			dictHash2.EN = AssignWord(dictHash2.EN, word.EN, standardizedWord)
+			dictHash2.EN = AssignWord(dictHash2.EN, word.EN, standardizedWord, true)
+			dictHash2Parenthesis.EN = AssignWord(dictHash2Parenthesis.EN, word.EN, standardizedWord, false)
 		}
 
 		// German (Deutsch)
 		if !NullDef(word.DE) {
-			dictHash2.DE = AssignWord(dictHash2.DE, word.DE, standardizedWord)
+			dictHash2.DE = AssignWord(dictHash2.DE, word.DE, standardizedWord, true)
+			dictHash2Parenthesis.DE = AssignWord(dictHash2Parenthesis.DE, word.DE, standardizedWord, false)
 		}
 
 		// Spanish (Español)
 		if !NullDef(word.ES) {
-			dictHash2.ES = AssignWord(dictHash2.ES, word.ES, standardizedWord)
+			dictHash2.ES = AssignWord(dictHash2.ES, word.ES, standardizedWord, true)
+			dictHash2Parenthesis.ES = AssignWord(dictHash2Parenthesis.ES, word.ES, standardizedWord, false)
 		}
 
 		// Estonian (Eesti)
 		if !NullDef(word.ET) {
-			dictHash2.ET = AssignWord(dictHash2.ET, word.ET, standardizedWord)
+			dictHash2.ET = AssignWord(dictHash2.ET, word.ET, standardizedWord, true)
+			dictHash2Parenthesis.ET = AssignWord(dictHash2Parenthesis.ET, word.ET, standardizedWord, false)
 		}
 
 		// French (Français)
 		if !NullDef(word.FR) {
-			dictHash2.FR = AssignWord(dictHash2.FR, word.FR, standardizedWord)
+			dictHash2.FR = AssignWord(dictHash2.FR, word.FR, standardizedWord, true)
+			dictHash2Parenthesis.FR = AssignWord(dictHash2Parenthesis.FR, word.FR, standardizedWord, false)
 		}
 
 		// Hungarian (Magyar)
 		if !NullDef(word.HU) {
-			dictHash2.HU = AssignWord(dictHash2.HU, word.HU, standardizedWord)
+			dictHash2.HU = AssignWord(dictHash2.HU, word.HU, standardizedWord, true)
+			dictHash2Parenthesis.HU = AssignWord(dictHash2Parenthesis.HU, word.HU, standardizedWord, false)
 		}
 
 		// Korean (한국어)
 		if !NullDef(word.KO) {
-			dictHash2.KO = AssignWord(dictHash2.KO, word.KO, standardizedWord)
+			dictHash2.KO = AssignWord(dictHash2.KO, word.KO, standardizedWord, true)
+			dictHash2Parenthesis.KO = AssignWord(dictHash2Parenthesis.KO, word.KO, standardizedWord, false)
 		}
 
 		// Dutch (Nederlands)
 		if !NullDef(word.NL) {
-			dictHash2.NL = AssignWord(dictHash2.NL, word.NL, standardizedWord)
+			dictHash2.NL = AssignWord(dictHash2.NL, word.NL, standardizedWord, true)
+			dictHash2Parenthesis.NL = AssignWord(dictHash2Parenthesis.NL, word.NL, standardizedWord, false)
 		}
 
 		// Polish (Polski)
 		if !NullDef(word.PL) {
-			dictHash2.PL = AssignWord(dictHash2.PL, word.PL, standardizedWord)
+			dictHash2.PL = AssignWord(dictHash2.PL, word.PL, standardizedWord, true)
+			dictHash2Parenthesis.PL = AssignWord(dictHash2Parenthesis.PL, word.PL, standardizedWord, false)
 		}
 
 		// Portuguese (Português)
 		if !NullDef(word.PT) {
-			dictHash2.PT = AssignWord(dictHash2.PT, word.PT, standardizedWord)
+			dictHash2.PT = AssignWord(dictHash2.PT, word.PT, standardizedWord, true)
+			dictHash2Parenthesis.PT = AssignWord(dictHash2Parenthesis.PT, word.PT, standardizedWord, false)
 		}
 
 		// Russian (Русский)
 		if !NullDef(word.RU) {
-			dictHash2.RU = AssignWord(dictHash2.RU, word.RU, standardizedWord)
+			dictHash2.RU = AssignWord(dictHash2.RU, word.RU, standardizedWord, true)
+			dictHash2Parenthesis.RU = AssignWord(dictHash2Parenthesis.RU, word.RU, standardizedWord, false)
 		}
 
 		// Swedish (Svenska)
 		if !NullDef(word.SV) {
-			dictHash2.SV = AssignWord(dictHash2.SV, word.SV, standardizedWord)
+			dictHash2.SV = AssignWord(dictHash2.SV, word.SV, standardizedWord, true)
+			dictHash2Parenthesis.SV = AssignWord(dictHash2Parenthesis.SV, word.SV, standardizedWord, false)
 		}
 
 		// Turkish (Türkçe)
 		if !NullDef(word.TR) {
-			dictHash2.TR = AssignWord(dictHash2.TR, word.TR, standardizedWord)
+			dictHash2.TR = AssignWord(dictHash2.TR, word.TR, standardizedWord, true)
+			dictHash2Parenthesis.TR = AssignWord(dictHash2Parenthesis.TR, word.TR, standardizedWord, false)
 		}
 
 		// Ukrainian (Українська)
 		if !NullDef(word.UK) {
-			dictHash2.UK = AssignWord(dictHash2.UK, word.UK, standardizedWord)
+			dictHash2.UK = AssignWord(dictHash2.UK, word.UK, standardizedWord, true)
+			dictHash2Parenthesis.UK = AssignWord(dictHash2Parenthesis.UK, word.UK, standardizedWord, false)
 		}
 		return nil
 	}
@@ -832,6 +858,21 @@ func UncacheHashDict2() {
 	dictHash2.SV = nil
 	dictHash2.TR = nil
 	dictHash2.UK = nil
+
+	dictHash2Parenthesis.EN = nil
+	dictHash2Parenthesis.DE = nil
+	dictHash2Parenthesis.ES = nil
+	dictHash2Parenthesis.ET = nil
+	dictHash2Parenthesis.FR = nil
+	dictHash2Parenthesis.HU = nil
+	dictHash2Parenthesis.KO = nil
+	dictHash2Parenthesis.NL = nil
+	dictHash2Parenthesis.PL = nil
+	dictHash2Parenthesis.PT = nil
+	dictHash2Parenthesis.RU = nil
+	dictHash2Parenthesis.SV = nil
+	dictHash2Parenthesis.TR = nil
+	dictHash2Parenthesis.UK = nil
 }
 
 // This will run the function `f` inside the cache or the file directly.

--- a/cache_test.go
+++ b/cache_test.go
@@ -37,7 +37,7 @@ func Test_cacheDict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error caching Dictionary!!")
 	}
-	entry := dictHash["'ampi"]
+	entry := dictHashLoose["'ampi"]
 	if !word.Equals(entry[0]) {
 		t.Errorf("Read wrong word from cache:\n"+
 			"Id: \"%s\" == \"%s\"\n"+

--- a/fwew.go
+++ b/fwew.go
@@ -498,7 +498,7 @@ func TranslateFromNaviHashHelper(dict *map[string][]Word, start int, allWords []
 				nucleusCount += strings.Count(a.Navi, b)
 			}
 			if nucleusCount == 1 {
-				if !containsUmlaut[i] && strings.Contains(a.Navi, "ä") {
+				if !containsUmlaut[i] && !strings.Contains(searchNaviWord, "a") && strings.Contains(a.Navi, "ä") {
 					continue
 				}
 			}
@@ -1042,7 +1042,7 @@ func dialectCrunch(query []string, guaranteedForest bool) []string {
 	for _, a := range query {
 		oldQuery := a
 
-		//a = strings.ReplaceAll(a, "ì", "i")
+		a = strings.ReplaceAll(a, "ì", "i")
 		// When caching, we are guaranteed forest words and don't need anything in this block
 		if !guaranteedForest {
 			for i, b := range nkx {

--- a/fwew.go
+++ b/fwew.go
@@ -642,7 +642,7 @@ func SearchNatlangWord(wordmap map[string][]string, searchWord string) (results 
 	firstResults := wordmap[searchWord]
 
 	for i := 0; i < len(firstResults); i++ {
-		for _, c := range dictHashLoose[firstResults[i]] {
+		for _, c := range dictHashStrict[firstResults[i]] {
 			results = AppendAndAlphabetize(results, c)
 		}
 	}
@@ -663,7 +663,7 @@ func TranslateToNaviHash(searchWord string, langCode string) (results [][]Word) 
 			continue
 		}
 		results = append(results, []Word{})
-		for _, a := range TranslateToNaviHashHelper(word, langCode) {
+		for _, a := range TranslateToNaviHashHelper(&dictHash2Parenthesis, word, langCode) {
 			results[len(results)-1] = AppendAndAlphabetize(results[len(results)-1], a)
 		}
 		// Append the query to the front of the list
@@ -674,13 +674,13 @@ func TranslateToNaviHash(searchWord string, langCode string) (results [][]Word) 
 	return
 }
 
-func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Word) {
+func TranslateToNaviHashHelper(dictionary *MetaDict, searchWord string, langCode string) (results []Word) {
 	results = []Word{}
 	switch langCode {
 	case "de": // German
-		for _, a := range SearchNatlangWord(dictHash2.DE, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).DE, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.DE)
+			searchWords := SearchTerms(a.DE, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -693,9 +693,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "en": // English
-		for _, a := range SearchNatlangWord(dictHash2.EN, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).EN, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.EN)
+			searchWords := SearchTerms(a.EN, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -708,9 +708,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "es": // Spanish
-		for _, a := range SearchNatlangWord(dictHash2.ES, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).ES, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.ES)
+			searchWords := SearchTerms(a.ES, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -723,9 +723,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "et": // Estonian
-		for _, a := range SearchNatlangWord(dictHash2.ET, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).ET, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.ET)
+			searchWords := SearchTerms(a.ET, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -738,9 +738,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "fr": // French
-		for _, a := range SearchNatlangWord(dictHash2.FR, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).FR, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.FR)
+			searchWords := SearchTerms(a.FR, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -753,9 +753,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "hu": // Hungarian
-		for _, a := range SearchNatlangWord(dictHash2.HU, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).HU, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.HU)
+			searchWords := SearchTerms(a.HU, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -768,9 +768,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "ko": // Korean
-		for _, a := range SearchNatlangWord(dictHash2.KO, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).KO, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.KO)
+			searchWords := SearchTerms(a.KO, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -783,9 +783,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "nl": // Dutch
-		for _, a := range SearchNatlangWord(dictHash2.NL, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).NL, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.NL)
+			searchWords := SearchTerms(a.NL, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -798,9 +798,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "pl": // Polish
-		for _, a := range SearchNatlangWord(dictHash2.PL, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).PL, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.PL)
+			searchWords := SearchTerms(a.PL, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -813,9 +813,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "pt": // Portuguese
-		for _, a := range SearchNatlangWord(dictHash2.PT, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).PT, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.PT)
+			searchWords := SearchTerms(a.PT, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -828,9 +828,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "ru": // Russian
-		for _, a := range SearchNatlangWord(dictHash2.RU, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).RU, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.RU)
+			searchWords := SearchTerms(a.RU, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -843,9 +843,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "sv": // Swedish
-		for _, a := range SearchNatlangWord(dictHash2.SV, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).SV, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.SV)
+			searchWords := SearchTerms(a.SV, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -858,9 +858,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "tr": // Turkish
-		for _, a := range SearchNatlangWord(dictHash2.TR, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).TR, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.TR)
+			searchWords := SearchTerms(a.TR, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -873,9 +873,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 			}
 		}
 	case "uk": // Ukrainian
-		for _, a := range SearchNatlangWord(dictHash2.UK, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).UK, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.UK)
+			searchWords := SearchTerms(a.UK, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -889,9 +889,9 @@ func TranslateToNaviHashHelper(searchWord string, langCode string) (results []Wo
 		}
 	default:
 		// If we get an odd language code, return English
-		for _, a := range SearchNatlangWord(dictHash2.EN, searchWord) {
+		for _, a := range SearchNatlangWord((*dictionary).EN, searchWord) {
 			// Verify the search query is actually in the definition
-			searchWords := SearchTerms(a.EN)
+			searchWords := SearchTerms(a.EN, false)
 			found := false
 			for _, d := range searchWords {
 				if d == searchWord {
@@ -945,7 +945,7 @@ func BidirectionalSearch(searchNaviWords string, checkFixes bool, langCode strin
 
 		// Search for natural language words
 		natlangWords := []Word{}
-		for _, a := range TranslateToNaviHashHelper(allWords[i], langCode) {
+		for _, a := range TranslateToNaviHashHelper(&dictHash2, allWords[i], langCode) {
 			// Do not duplicate if the Na'vi word is in the definition
 			if implContainsAny(NaviIDs, []string{a.ID}) {
 				continue

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -816,7 +816,19 @@ var naviWords = []struct {
 				},
 			},
 		},
-	}, // Out of the air
+	}, // Leave (subjunctive, reef)
+	{
+		name: "ila",
+		args: args{
+			searchNaviText: "ila",
+		},
+		want: []Word{
+			{
+				ID:   "648",
+				Navi: "ìlä+",
+			},
+		},
+	}, // See if it can search words without diacritics
 }
 var englishWords = []struct {
 	name string

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -879,35 +879,6 @@ var englishWords = []struct {
 		},
 	},
 	{
-		name: "Tier",
-		args: args{
-			searchNaviText: "Tier",
-			languageCode:   "de",
-		},
-		want: []Word{
-			{
-				ID:   "612",
-				Navi: "ioang",
-			},
-			{
-				ID:   "9460",
-				Navi: "kxänäng",
-			},
-			{
-				ID:   "1440",
-				Navi: "pa'li",
-			},
-			{
-				ID:   "2124",
-				Navi: "tireaioang",
-			},
-			{
-				ID:   "2744",
-				Navi: "yerik",
-			},
-		},
-	},
-	{
 		name: "Zehe",
 		args: args{
 			searchNaviText: "Zehe",
@@ -985,6 +956,90 @@ var englishWords = []struct {
 			{
 				ID:   "11380",
 				Navi: "kxì",
+			},
+		},
+	},
+}
+
+var englishNoParen = []struct {
+	name string
+	args args
+	want []Word
+}{
+	{
+		name: "Tier",
+		args: args{
+			searchNaviText: "Tier",
+			languageCode:   "de",
+		},
+		want: []Word{
+			{
+				ID:   "612",
+				Navi: "ioang",
+			},
+			{
+				ID:   "9460",
+				Navi: "kxänäng",
+			},
+			{
+				ID:   "1440",
+				Navi: "pa'li",
+			},
+			{
+				ID:   "2124",
+				Navi: "tireaioang",
+			},
+			{
+				ID:   "2744",
+				Navi: "yerik",
+			},
+		},
+	},
+}
+
+var englishParen = []struct {
+	name string
+	args args
+	want []Word
+}{
+	{
+		name: "Tier",
+		args: args{
+			searchNaviText: "Tier",
+			languageCode:   "de",
+		},
+		want: []Word{
+			{
+				ID:   "440",
+				Navi: "fpxafaw",
+			},
+			{
+				ID:   "7676",
+				Navi: "fwampop",
+			},
+			{
+				ID:   "612",
+				Navi: "ioang",
+			},
+			{
+				ID:   "9460",
+				Navi: "kxänäng",
+			},
+			{
+				ID:   "1440",
+				Navi: "pa'li",
+			},
+			{
+				ID:   "10704",
+				Navi: "seyto",
+			},
+			{
+				ID:   "2124",
+				Navi: "tireaioang",
+			},
+			{
+				ID:   "2744",
+				Navi: "yerik",
 			},
 		},
 	},
@@ -1111,6 +1166,15 @@ func TestTranslateToNaviCached(t *testing.T) {
 		})
 	}
 
+	for _, tt := range englishParen {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResults := TranslateToNaviHash(tt.args.searchNaviText, tt.args.languageCode)
+			if !wordSimpleEqual(gotResults[0][1:], tt.want) {
+				t.Errorf("TranslateToNavi() = %v, want %v", gotResults[0][1:], tt.want)
+			}
+		})
+	}
+
 	UncacheHashDict()
 	UncacheHashDict2()
 }
@@ -1132,6 +1196,15 @@ func TestBidirectionalCached(t *testing.T) {
 	}
 
 	for _, tt := range englishWords {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResults, _ := BidirectionalSearch(tt.args.searchNaviText, true, tt.args.languageCode)
+			if !wordSimpleEqual(gotResults[0][1:], tt.want) {
+				t.Errorf("TranslateToNavi() = %v, want %v", gotResults[0][1:], tt.want)
+			}
+		})
+	}
+
+	for _, tt := range englishNoParen {
 		t.Run(tt.name, func(t *testing.T) {
 			gotResults, _ := BidirectionalSearch(tt.args.searchNaviText, true, tt.args.languageCode)
 			if !wordSimpleEqual(gotResults[0][1:], tt.want) {

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -329,14 +329,14 @@ var naviWords = []struct {
 		},
 	}, // zenke `yu` override
 	{
-		name: "ner",
+		name: "ferfen",
 		args: args{
-			searchNaviText: "ner",
+			searchNaviText: "ferfen",
 		},
 		want: []Word{
 			{
-				ID:   "9116",
-				Navi: "nrr",
+				ID:   "464",
+				Navi: "frrfen",
 				Affixes: affix{
 					Infix: []string{
 						"er",

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -975,7 +975,7 @@ func TestTranslateFromNaviCached(t *testing.T) {
 		wordWord := Word{Navi: "tsun", ID: "13353", Affixes: affixes}
 		want := []Word{wordWord}
 		t.Run(word, func(t *testing.T) {
-			got, err := TranslateFromNaviHash(word, true)
+			got, err := TranslateFromNaviHash(word, true, false)
 			if err == nil && word == "" && got != nil {
 				t.Errorf("TranslateFromNaviCached() got = %v, want %v", got, want)
 			} else if err == nil && len(want) == 0 && len(got) > 0 {
@@ -988,7 +988,7 @@ func TestTranslateFromNaviCached(t *testing.T) {
 
 	for _, tt := range naviWords {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := TranslateFromNaviHash(tt.args.searchNaviText, true)
+			got, err := TranslateFromNaviHash(tt.args.searchNaviText, true, false)
 			if err == nil && tt.args.searchNaviText == "" && got != nil {
 				t.Errorf("TranslateFromNaviCached() got = %v, want %v", got, tt.want)
 			} else if err == nil && len(tt.want) == 0 && len(got) > 0 {
@@ -1007,7 +1007,7 @@ func BenchmarkTranslateFromNavi(b *testing.B) {
 	for _, bm := range naviWords {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				TranslateFromNaviHash(bm.args.searchNaviText, true)
+				TranslateFromNaviHash(bm.args.searchNaviText, true, false)
 			}
 		})
 	}
@@ -1032,7 +1032,7 @@ func BenchmarkTranslateFromNaviBig(b *testing.B) {
 
 		b.Run(line, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				TranslateFromNaviHash(line, true)
+				TranslateFromNaviHash(line, true, false)
 			}
 		})
 	}

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -329,14 +329,14 @@ var naviWords = []struct {
 		},
 	}, // zenke `yu` override
 	{
-		name: "verìn",
+		name: "ner",
 		args: args{
-			searchNaviText: "verìn",
+			searchNaviText: "ner",
 		},
 		want: []Word{
 			{
-				ID:   "6884",
-				Navi: "vrrìn",
+				ID:   "9116",
+				Navi: "nrr",
 				Affixes: affix{
 					Infix: []string{
 						"er",

--- a/fwew_test.go
+++ b/fwew_test.go
@@ -829,6 +829,36 @@ var naviWords = []struct {
 			},
 		},
 	}, // See if it can search words without diacritics
+	{
+		name: "wayila",
+		args: args{
+			searchNaviText: "wayila",
+		},
+		want: []Word{
+			{
+				ID:   "2692",
+				Navi: "way",
+				Affixes: affix{
+					Suffix: []string{"ìlä"},
+				},
+			},
+		},
+	}, // See if it can search words without diacritics
+	{
+		name: "sangi",
+		args: args{
+			searchNaviText: "sangi",
+		},
+		want: []Word{
+			{
+				ID:   "1788",
+				Navi: "si",
+				Affixes: affix{
+					Infix: []string{"äng"},
+				},
+			},
+		},
+	}, // See if it can search words without diacritics
 }
 var englishWords = []struct {
 	name string


### PR DESCRIPTION
- When searching Na'vi words, diacritics like _Ä_ and _Ì_ are now optional
- A new "strict mode" for forest dialect only
- When searching natural language words, bidirectional won't search in parenthesis, but natlang to Na'vi will
- Updated unit tests, including changing _vrrin_ to _frrfen_ given _verìn_ and _verin_ are different words in forest but both show up when searching _vrrin_ in non-strict mode

Others
- Borrowed a technique from the homonym detector passing a reference to the wanted dictionary
- Storing "strict" and "loose" versions of the dictionary